### PR TITLE
Add AMI mappings for supported regions

### DIFF
--- a/examples/infrastructure/ecs-cluster.yaml
+++ b/examples/infrastructure/ecs-cluster.yaml
@@ -33,8 +33,15 @@ Parameters:
 Mappings:
 
   AWSRegionToECSAmi:
+    eu-west-1:
+      AMI: ami-0627e141ce928067c
+    us-east-1:
+      AMI: ami-045f1b3f87ed83659
+    us-east-2:
+      AMI: ami-0307f7ccf6ea35750
     us-west-2:
-      AMI: ami-09568291a9d6c804c
+      AMI: ami-01b70aea4161476b7
+
 
 Resources:
 

--- a/examples/infrastructure/eks-cluster.yaml
+++ b/examples/infrastructure/eks-cluster.yaml
@@ -49,6 +49,12 @@ Parameters:
 Mappings:
 
   AWSRegionToEKSAMI:
+    eu-west-1:
+      AMI: ami-00c3b2d35bddd4f5c
+    us-east-1:
+      AMI: ami-0a0b913ef3249b655
+    us-east-2:
+      AMI: ami-0958a76db2d150238
     us-west-2:
       AMI: ami-0f54a2f7d2e9c88b3
 


### PR DESCRIPTION
Adds AMI mappings for AppMesh's preview launch regions.

ECS AMIs sourced from: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html
EKS AmIs sourced from: https://docs.aws.amazon.com/eks/latest/userguide/eks-optimized-ami.html