### PR TITLE
Adding colorteller-route weight as default for first installation demos

### DIFF
--- a/examples/apps/colorapp/servicemesh/config/routes/colorteller-route.json
+++ b/examples/apps/colorapp/servicemesh/config/routes/colorteller-route.json
@@ -6,7 +6,15 @@
                 "weightedTargets": [
                     {
                         "virtualNode": "colorteller-vn",
-                        "weight": 1
+                        "weight": 30
+                    },
+                    {
+                        "virtualNode": "colorteller-black-vn",
+                        "weight": 30
+                    },
+                    {
+                        "virtualNode": "colorteller-blue-vn",
+                        "weight": 40
                     }
                 ]
             },


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

On first installation better to have weight apply for demo

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
