### PR TITLE
Rounding stats in gateway

### DIFF
--- a/examples/apps/colorapp/src/gateway/deploy.sh
+++ b/examples/apps/colorapp/src/gateway/deploy.sh
@@ -12,5 +12,9 @@ fi
 docker build -t $COLOR_GATEWAY_IMAGE .
 
 # push
-$(aws ecr get-login --no-include-email --region $AWS_REGION --profile $AWS_PROFILE)
+if [ -z $AWS_PROFILE  ]; then
+    $(aws ecr get-login --no-include-email --region $AWS_REGION)
+else
+    $(aws ecr get-login --no-include-email --region $AWS_REGION --profile $AWS_PROFILE)
+fi
 docker push $COLOR_GATEWAY_IMAGE

--- a/examples/apps/colorapp/src/gateway/main.go
+++ b/examples/apps/colorapp/src/gateway/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"math"
 	"net"
 	"net/http"
 	"os"
@@ -82,7 +83,8 @@ func getRatios() map[string]float64 {
 
 	ratios := make(map[string]float64)
 	for k, v := range counts {
-		ratios[k] = float64(v) / float64(total)
+		ratio := float64(v) / float64(total)
+		ratios[k] = math.Round(ratio*100) / 100
 	}
 
 	return ratios


### PR DESCRIPTION
*Description of changes:* 
- Allow running src/colorapp/gateway/deploy.sh without AWS_PROFILE (e.g. ec2 dev box)
- Rounding stats in gateway

```
{"color":"blue", "stats": {"blue":0.8,"red":0.2}}

instead of 

{"color":"blue", "stats": {"blue":0.79997625,"red": 0.20002375}}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
