### PR TITLE
Wait for Envoy container to reach `live` state before considering healthy

### DIFF
--- a/examples/apps/colorapp/ecs/envoy-container.json
+++ b/examples/apps/colorapp/ecs/envoy-container.json
@@ -60,7 +60,7 @@
   "healthCheck": {
     "command": [
       "CMD-SHELL",
-      "curl -f http://localhost:9901/server_info || exit 1"
+      "curl -s http://localhost:9901/server_info | cut -d' ' -f3 | grep -q live"
     ],
     "interval": 5,
     "timeout": 2,


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/aws-app-mesh-roadmap/issues/44

*Description of changes:*

Wait for the Envoy container to reach the [live server state](https://www.envoyproxy.io/docs/envoy/latest/api-v2/admin/v2alpha/server_info.proto#envoy-api-enum-admin-v2alpha-serverinfo-state) before determining it as healthy.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
