### PR TITLE
Update Envoy container health check for Envoy v1.9

### DIFF
--- a/examples/apps/colorapp/ecs/envoy-container.json
+++ b/examples/apps/colorapp/ecs/envoy-container.json
@@ -60,7 +60,7 @@
   "healthCheck": {
     "command": [
       "CMD-SHELL",
-      "curl -s http://localhost:9901/server_info | cut -d' ' -f3 | grep -q live"
+      "curl -s http://localhost:9901/server_info | grep state | grep -q LIVE"
     ],
     "interval": 5,
     "timeout": 2,


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Update health check for Envoy v1.9

In Envoy 1.8.0.2, the output of `:9901/server_info` was:
```
envoy c74766d7261bd56f8ffa1a06ebb9325f66fe6263/1.8.0/Clean/DEBUG live 12 12 0
```

However, in Envoy 1.9, the output was changed to JSON:
```
{
 "version": "ae8c8aa036e58e39b3d2fba81f5bdc4683a30682/1.9.0/Clean/DEBUG/BoringSSL",
 "state": "LIVE",
 "command_line_options": {
  "base_id": "0",
  "concurrency": 16,
  "config_path": "/envoys/egress-all.yaml",
  "config_yaml": "",
  "allow_unknown_fields": false,
  "admin_address_path": "",
  "local_address_ip_version": "v4",
  "log_level": "debug",
  "component_log_level": "",
  "log_format": "[%Y-%m-%d %T.%e][%t][%l][%n] %v",
  "log_path": "",
  "hot_restart_version": false,
  "service_cluster": "",
  "service_node": "",
  "service_zone": "",
  "mode": "Serve",
  "max_stats": "16384",
  "max_obj_name_len": "60",
  "disable_hot_restart": false,
  "enable_mutex_tracing": false,
  "restart_epoch": 0,
  "file_flush_interval": "10s",
  "drain_time": "600s",
  "parent_shutdown_time": "900s"
 },
 "uptime_current_epoch": "3s",
 "uptime_all_epochs": "3s"
}
```

The published Envoy container does not currently have `jq` installed, so this check will first search for the `state` line, followed by the `LIVE` value within that line.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
