### PR TITLE
Add a public load balancer for the color app

### DIFF
--- a/examples/apps/colorapp/ecs/ecs-colorapp.yaml
+++ b/examples/apps/colorapp/ecs/ecs-colorapp.yaml
@@ -32,6 +32,13 @@ Parameters:
     Type: String
     Description: Task definition for ColorTeller Black Service
 
+  Path:
+    Type: String
+    Default: "*"
+    Description: A path on the public load balancer that this service
+                 should be connected to. Use * to send all load balancer
+                 traffic to this service.
+
 Resources:
 
   ### colorteller.default.svc.cluster.local
@@ -198,6 +205,8 @@ Resources:
 
   ColorGatewayService:
     Type: 'AWS::ECS::Service'
+    DependsOn:
+      - WebLoadBalancerRule
     Properties:
       Cluster:
         'Fn::ImportValue': !Sub "${EnvironmentName}:ECSCluster"
@@ -218,6 +227,10 @@ Resources:
             - 'Fn::ImportValue': !Sub "${EnvironmentName}:PrivateSubnet1"
             - 'Fn::ImportValue': !Sub "${EnvironmentName}:PrivateSubnet2"
       TaskDefinition: { Ref: ColorGatewayTaskDefinition }
+      LoadBalancers:
+        - ContainerName: app
+          ContainerPort: 9080
+          TargetGroupArn: !Ref WebTargetGroup
 
   ### tester
   TesterService:
@@ -329,3 +342,47 @@ Resources:
         'Fn::ImportValue': !Sub "${EnvironmentName}:TaskIamRoleArn"
       NetworkMode: "awsvpc"
       Memory: 256
+
+  WebTargetGroup:
+    Type: AWS::ElasticLoadBalancingV2::TargetGroup
+    Properties:
+      HealthCheckIntervalSeconds: 6
+      HealthCheckPath: /
+      HealthCheckProtocol: HTTP
+      HealthCheckTimeoutSeconds: 5
+      HealthyThresholdCount: 2
+      TargetType: ip
+      Name: !Join ['-', [!Ref 'EnvironmentName', 'web']]
+      Name: !Sub "${EnvironmentName}-web"
+      Port: 80
+      Protocol: HTTP
+      UnhealthyThresholdCount: 2
+      TargetGroupAttributes:
+        - Key: deregistration_delay.timeout_seconds
+          Value: 30
+      VpcId:
+        'Fn::ImportValue': !Sub "${EnvironmentName}:VPC"
+  
+  WebLoadBalancerRule:
+    Type: AWS::ElasticLoadBalancingV2::ListenerRule
+    Properties:
+      Actions:
+        - TargetGroupArn: !Ref 'WebTargetGroup'
+          Type: 'forward'
+      Conditions:
+        - Field: path-pattern
+          Values: [!Ref 'Path']
+      ListenerArn: 
+        'Fn::ImportValue': !Sub "${EnvironmentName}:PublicListener"
+      Priority: 1
+
+Outputs: 
+
+  PublicHTTP:
+    Description: Public endpoint for Color App service
+    Value:
+      'Fn::ImportValue': !Sub "${EnvironmentName}:PublicHTTP"
+    Export:
+        Name: !Sub "${EnvironmentName}:ColorAppEndpoint"
+
+

--- a/examples/apps/colorapp/ecs/ecs-colorapp.yaml
+++ b/examples/apps/colorapp/ecs/ecs-colorapp.yaml
@@ -343,6 +343,29 @@ Resources:
       NetworkMode: "awsvpc"
       Memory: 256
 
+  PublicLoadBalancerSG:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Access to the public facing load balancer
+      VpcId:
+        'Fn::ImportValue': !Sub "${EnvironmentName}:VPC"
+      SecurityGroupIngress:
+          - CidrIp: 0.0.0.0/0
+            IpProtocol: -1
+
+  # public ALB for color gateway
+  PublicLoadBalancer:
+    Type: AWS::ElasticLoadBalancingV2::LoadBalancer
+    Properties:
+      Scheme: internet-facing
+      LoadBalancerAttributes:
+        - Key: idle_timeout.timeout_seconds
+          Value: '30'
+      Subnets:
+        - { 'Fn::ImportValue': !Sub "${EnvironmentName}:PublicSubnet1" }  
+        - { 'Fn::ImportValue': !Sub "${EnvironmentName}:PublicSubnet2" }  
+      SecurityGroups: [!Ref 'PublicLoadBalancerSG']
+
   WebTargetGroup:
     Type: AWS::ElasticLoadBalancingV2::TargetGroup
     Properties:
@@ -363,26 +386,33 @@ Resources:
       VpcId:
         'Fn::ImportValue': !Sub "${EnvironmentName}:VPC"
   
+  PublicLoadBalancerListener:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    DependsOn:
+      - PublicLoadBalancer
+    Properties:
+      DefaultActions:
+        - TargetGroupArn: !Ref WebTargetGroup
+          Type: 'forward'
+      LoadBalancerArn: !Ref 'PublicLoadBalancer'
+      Port: 80
+      Protocol: HTTP
+
   WebLoadBalancerRule:
     Type: AWS::ElasticLoadBalancingV2::ListenerRule
     Properties:
       Actions:
-        - TargetGroupArn: !Ref 'WebTargetGroup'
+        - TargetGroupArn: !Ref WebTargetGroup
           Type: 'forward'
       Conditions:
         - Field: path-pattern
           Values: [!Ref 'LoadBalancerPath']
-      ListenerArn: 
-        'Fn::ImportValue': !Sub "${EnvironmentName}:PublicListener"
+      ListenerArn: !Ref PublicLoadBalancerListener
       Priority: 1
 
 Outputs: 
 
-  PublicHTTP:
+  ColorAppEndpoint:
     Description: Public endpoint for Color App service
-    Value:
-      'Fn::ImportValue': !Sub "${EnvironmentName}:PublicHTTP"
-    Export:
-        Name: !Sub "${EnvironmentName}:ColorAppEndpoint"
-
+    Value: !Join ['', ['http://', !GetAtt 'PublicLoadBalancer.DNSName']]
 

--- a/examples/apps/colorapp/ecs/ecs-colorapp.yaml
+++ b/examples/apps/colorapp/ecs/ecs-colorapp.yaml
@@ -32,7 +32,7 @@ Parameters:
     Type: String
     Description: Task definition for ColorTeller Black Service
 
-  Path:
+  LoadBalancerPath:
     Type: String
     Default: "*"
     Description: A path on the public load balancer that this service
@@ -359,7 +359,7 @@ Resources:
       UnhealthyThresholdCount: 2
       TargetGroupAttributes:
         - Key: deregistration_delay.timeout_seconds
-          Value: 30
+          Value: 120
       VpcId:
         'Fn::ImportValue': !Sub "${EnvironmentName}:VPC"
   
@@ -371,7 +371,7 @@ Resources:
           Type: 'forward'
       Conditions:
         - Field: path-pattern
-          Values: [!Ref 'Path']
+          Values: [!Ref 'LoadBalancerPath']
       ListenerArn: 
         'Fn::ImportValue': !Sub "${EnvironmentName}:PublicListener"
       Priority: 1

--- a/examples/infrastructure/vpc.yaml
+++ b/examples/infrastructure/vpc.yaml
@@ -201,55 +201,6 @@ Resources:
       RouteTableId: !Ref PrivateRouteTable2
       SubnetId: !Ref PrivateSubnet2
 
-  PublicLoadBalancerSG:
-    Type: AWS::EC2::SecurityGroup
-    Properties:
-      GroupDescription: Access to the public facing load balancer
-      VpcId: !Ref VPC
-      SecurityGroupIngress:
-          - CidrIp: 0.0.0.0/0
-            IpProtocol: -1
-
-  PublicLoadBalancer:
-    Type: AWS::ElasticLoadBalancingV2::LoadBalancer
-    Properties:
-      Scheme: internet-facing
-      LoadBalancerAttributes:
-        - Key: idle_timeout.timeout_seconds
-          Value: '30'
-      Subnets:
-        - !Ref PublicSubnet1
-        - !Ref PublicSubnet2
-      SecurityGroups: [!Ref 'PublicLoadBalancerSG']
-
-  # Initial placeholder target group to drop traffic; actual target group
-  # creation is deferred to a later application stack
-  PlaceholderTargetGroupPublic:
-    Type: AWS::ElasticLoadBalancingV2::TargetGroup
-    Properties:
-      HealthCheckIntervalSeconds: 6
-      HealthCheckPath: /
-      HealthCheckProtocol: HTTP
-      HealthCheckTimeoutSeconds: 5
-      HealthyThresholdCount: 2
-      Name: !Sub "${EnvironmentName}-drop-1"
-      Port: 80
-      Protocol: HTTP
-      UnhealthyThresholdCount: 2
-      VpcId: !Ref VPC
-
-  PublicLoadBalancerListener:
-    Type: AWS::ElasticLoadBalancingV2::Listener
-    DependsOn:
-      - PublicLoadBalancer
-    Properties:
-      DefaultActions:
-        - TargetGroupArn: !Ref 'PlaceholderTargetGroupPublic'
-          Type: 'forward'
-      LoadBalancerArn: !Ref 'PublicLoadBalancer'
-      Port: 80
-      Protocol: HTTP
-
 Outputs: 
 
   VPC: 
@@ -287,23 +238,4 @@ Outputs:
     Value: !Ref VpcCIDR
     Export:
       Name: !Sub "${EnvironmentName}:VpcCIDR"
-
-  PublicLoadBalancer:
-    Description: The ARN of the public load balancer
-    Value: !Ref PublicLoadBalancer
-    Export:
-      Name: !Sub "${EnvironmentName}:PublicLoadBalancer"
-
-  PublicListener:
-    Description: The ARN of the public load balancer's Listener
-    Value: !Ref PublicLoadBalancerListener
-    Export:
-      Name: !Sub "${EnvironmentName}:PublicListener"
-
-  PublicHTTP:
-    Description: Public load balancer base HTTP URL for service endpoints
-    Value: !Join ['', ['http://', !GetAtt 'PublicLoadBalancer.DNSName']]
-    Export:
-      Name: !Sub "${EnvironmentName}:PublicHTTP"
-
 

--- a/examples/infrastructure/vpc.yaml
+++ b/examples/infrastructure/vpc.yaml
@@ -159,7 +159,6 @@ Resources:
       RouteTableId: !Ref PublicRouteTable
       SubnetId: !Ref PublicSubnet2
   
-
   PrivateRouteTable1:
     Type: AWS::EC2::RouteTable
     Properties: 
@@ -202,6 +201,55 @@ Resources:
       RouteTableId: !Ref PrivateRouteTable2
       SubnetId: !Ref PrivateSubnet2
 
+  PublicLoadBalancerSG:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Access to the public facing load balancer
+      VpcId: !Ref VPC
+      SecurityGroupIngress:
+          - CidrIp: 0.0.0.0/0
+            IpProtocol: -1
+
+  PublicLoadBalancer:
+    Type: AWS::ElasticLoadBalancingV2::LoadBalancer
+    Properties:
+      Scheme: internet-facing
+      LoadBalancerAttributes:
+        - Key: idle_timeout.timeout_seconds
+          Value: '30'
+      Subnets:
+        - !Ref PublicSubnet1
+        - !Ref PublicSubnet2
+      SecurityGroups: [!Ref 'PublicLoadBalancerSG']
+
+  # Initial placeholder target group to drop traffic; actual target group
+  # creation is deferred to a later application stack
+  PlaceholderTargetGroupPublic:
+    Type: AWS::ElasticLoadBalancingV2::TargetGroup
+    Properties:
+      HealthCheckIntervalSeconds: 6
+      HealthCheckPath: /
+      HealthCheckProtocol: HTTP
+      HealthCheckTimeoutSeconds: 5
+      HealthyThresholdCount: 2
+      Name: !Sub "${EnvironmentName}-drop-1"
+      Port: 80
+      Protocol: HTTP
+      UnhealthyThresholdCount: 2
+      VpcId: !Ref VPC
+
+  PublicLoadBalancerListener:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    DependsOn:
+      - PublicLoadBalancer
+    Properties:
+      DefaultActions:
+        - TargetGroupArn: !Ref 'PlaceholderTargetGroupPublic'
+          Type: 'forward'
+      LoadBalancerArn: !Ref 'PublicLoadBalancer'
+      Port: 80
+      Protocol: HTTP
+
 Outputs: 
 
   VPC: 
@@ -239,3 +287,23 @@ Outputs:
     Value: !Ref VpcCIDR
     Export:
       Name: !Sub "${EnvironmentName}:VpcCIDR"
+
+  PublicLoadBalancer:
+    Description: The ARN of the public load balancer
+    Value: !Ref PublicLoadBalancer
+    Export:
+      Name: !Sub "${EnvironmentName}:PublicLoadBalancer"
+
+  PublicListener:
+    Description: The ARN of the public load balancer's Listener
+    Value: !Ref PublicLoadBalancerListener
+    Export:
+      Name: !Sub "${EnvironmentName}:PublicListener"
+
+  PublicHTTP:
+    Description: Public load balancer base HTTP URL for service endpoints
+    Value: !Join ['', ['http://', !GetAtt 'PublicLoadBalancer.DNSName']]
+    Export:
+      Name: !Sub "${EnvironmentName}:PublicHTTP"
+
+


### PR DESCRIPTION
*Description of changes:*

This PR adds a public load balancer to the Color App stack so that the gateway endpoint is accessible over the Internet (only for the `ecs-colorapp.yaml` deployment for now). The endpoint is output as `ColorAppEndpoint` when the ecs-colorapp stack is deployed.

Test:
1. Deploy stacks.
2. Curl the endpoint:

```
$ EP=$(aws cloudformation describe-stacks --stack-name=$ENVIRONMENT_NAME-ecs-colorapp --query="Stacks[0].Outputs[?OutputKey=='ColorAppEndpoint'].OutputValue" --output=text)

$ curl $EP/color
{"color":"white", "stats": {"white":1}}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
