### PR TITLE
Add bastion host to ecs-cluster

### DIFF
--- a/examples/infrastructure/ecs-cluster.yaml
+++ b/examples/infrastructure/ecs-cluster.yaml
@@ -31,9 +31,14 @@ Parameters:
     Description: "Domain name registerd under Route-53 that will be used for Service Discovery"
 
   ECSAmi:
-    Description: AMI ID
+    Description: ECS AMI ID
     Type: AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
     Default: "/aws/service/ecs/optimized-ami/amazon-linux/recommended/image_id"
+
+  EC2Ami:
+    Description: EC2 AMI ID
+    Type: AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
+    Default: "/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2"
 
 Resources:
 
@@ -360,6 +365,32 @@ Resources:
         'Fn::ImportValue': !Sub "${EnvironmentName}:VPC"
       Name: { Ref: ECSServicesDomain }
 
+  BastionSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Allow http to client host
+      VpcId: 
+        'Fn::ImportValue': !Sub "${EnvironmentName}:VPC"
+      SecurityGroupIngress:
+      - IpProtocol: tcp
+        FromPort: 22
+        ToPort: 22
+        CidrIp: 0.0.0.0/0
+
+  BastionHost:
+    Type: AWS::EC2::Instance
+    Properties: 
+      ImageId: !Ref EC2Ami
+      KeyName: !Ref KeyName
+      InstanceType: t2.micro
+      SecurityGroupIds:
+      - !Ref BastionSecurityGroup
+      SubnetId: 
+        'Fn::ImportValue': !Sub "${EnvironmentName}:PublicSubnet1"
+      Tags: 
+        - Key: Name
+          Value: bastion-host
+
 Outputs:
 
   Cluster:
@@ -405,3 +436,9 @@ Outputs:
     Value: { "Fn::GetAtt": TaskIamRole.Arn }
     Export:
       Name: !Sub "${EnvironmentName}:TaskIamRoleArn"
+
+  BastionIP:
+    Description: Public IP for ssh access to bastion host
+    Value:
+      'Fn::GetAtt': [ BastionHost, PublicIp ]
+


### PR DESCRIPTION
*Description of changes:*

This PR adds a public bastion to the ECS cluster stack to help in testing/debugging scenarios. The bastion's public IP is exported (as `BastionIP`) when the `ecs-cluster` stack is deployed.

Test:
1. Deploy stacks.
2. ssh into the bastion

```
$ BASTION=$(aws cloudformation describe-stacks --stack-name=DEMO-ecs-cluster --query="Stacks[0].Outputs[?OutputKey=='BastionIP'].OutputValue" --output text)
$ ssh ec2-user@$BASTION
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
