### PR TITLE
Add /ping handler to gateway, adjust ELB HC path

### DIFF
--- a/examples/apps/colorapp/ecs/ecs-colorapp.yaml
+++ b/examples/apps/colorapp/ecs/ecs-colorapp.yaml
@@ -370,7 +370,7 @@ Resources:
     Type: AWS::ElasticLoadBalancingV2::TargetGroup
     Properties:
       HealthCheckIntervalSeconds: 6
-      HealthCheckPath: /
+      HealthCheckPath: /ping
       HealthCheckProtocol: HTTP
       HealthCheckTimeoutSeconds: 5
       HealthyThresholdCount: 2

--- a/examples/apps/colorapp/src/gateway/main.go
+++ b/examples/apps/colorapp/src/gateway/main.go
@@ -193,6 +193,13 @@ func (h *tcpEchoHandler) ServeHTTP(writer http.ResponseWriter, request *http.Req
 	fmt.Fprintf(writer, "Response from tcpecho server: %s", reply)
 }
 
+type pingHandler struct{}
+
+func (h *pingHandler) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
+	log.Println("ping requested, reponding with HTTP 200")
+	writer.WriteHeader(http.StatusOK)
+}
+
 func main() {
 	log.Println("Starting server, listening on port " + getServerPort())
 
@@ -213,5 +220,6 @@ func main() {
 	http.Handle("/color", xray.Handler(xraySegmentNamer, &colorHandler{}))
 	http.Handle("/color/clear", xray.Handler(xraySegmentNamer, &clearColorStatsHandler{}))
 	http.Handle("/tcpecho", xray.Handler(xraySegmentNamer, &tcpEchoHandler{}))
+	http.Handle("/ping", xray.Handler(xraySegmentNamer, &pingHandler{}))
 	log.Fatal(http.ListenAndServe(":"+getServerPort(), nil))
 }


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Resolves the issue were the new ELB will consistently kill the ECS task due to it not responding on the health check path "/"


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
