### PR TITLE
Minor edit: remove redundant name assignment

### DIFF
--- a/examples/apps/colorapp/ecs/ecs-colorapp.yaml
+++ b/examples/apps/colorapp/ecs/ecs-colorapp.yaml
@@ -375,7 +375,6 @@ Resources:
       HealthCheckTimeoutSeconds: 5
       HealthyThresholdCount: 2
       TargetType: ip
-      Name: !Join ['-', [!Ref 'EnvironmentName', 'web']]
       Name: !Sub "${EnvironmentName}-web"
       Port: 80
       Protocol: HTTP


### PR DESCRIPTION
*Description of changes:*

Remove extra name assignment for ecs-colorapp stack.

*Test*

After deploying stack, confirm expected target group exists:

```
$ aws elbv2 describe-target-groups --query "TargetGroups[?TargetGroupName=='"$ENVIRONMENT_NAME"-web']"
[
    {
        "TargetGroupArn": "arn:aws:elasticloadbalancing:us-west-2:226767807331:targetgroup/DEMO-web/4fececd5a30cda7c",
        "TargetGroupName": "DEMO-web",
...
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
