### PR TITLE
Make the TesterService deployment optional

### DIFF
--- a/examples/apps/colorapp/ecs/ecs-colorapp.sh
+++ b/examples/apps/colorapp/ecs/ecs-colorapp.sh
@@ -4,6 +4,14 @@ set -ex
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 
+# ecs-colorapp.yaml expects "true" or "false" (default is "false")
+# will deploy the TesterService, which perpetually invokes /color to generate history
+: "${DEPLOY_TESTER:='false'}"
+
+
+echo "DEPLOY_TESTER=${DEPLOY_TESTER}"
+exit
+
 # Creating Task Definitions
 source ${DIR}/create-task-defs.sh
 
@@ -20,4 +28,6 @@ aws --profile "${AWS_PROFILE}" --region "${AWS_DEFAULT_REGION}" \
     ColorTellerWhiteTaskDefinition="${colorteller_white_task_def_arn}" \
     ColorTellerRedTaskDefinition="${colorteller_red_task_def_arn}" \
     ColorTellerBlueTaskDefinition="${colorteller_blue_task_def_arn}" \
-    ColorTellerBlackTaskDefinition="${colorteller_black_task_def_arn}"
+    ColorTellerBlackTaskDefinition="${colorteller_black_task_def_arn}" \
+    DeployTester="${DEPLOY_TESTER}"
+

--- a/examples/apps/colorapp/ecs/ecs-colorapp.yaml
+++ b/examples/apps/colorapp/ecs/ecs-colorapp.yaml
@@ -39,6 +39,18 @@ Parameters:
                  should be connected to. Use * to send all load balancer
                  traffic to this service.
 
+  DeployTester:
+    Type: String
+    Default: false
+    AllowedValues:
+      - true
+      - false
+    Description: Set to "true" to include the TesterService (to generate color history)
+
+Conditions:
+  ShouldDeployTester:
+    !Equals [true, !Ref DeployTester]
+
 Resources:
 
   ### colorteller.default.svc.cluster.local
@@ -235,6 +247,7 @@ Resources:
   ### tester
   TesterService:
     Type: 'AWS::ECS::Service'
+    Condition: ShouldDeployTester
     Properties:
       Cluster:
         'Fn::ImportValue': !Sub "${EnvironmentName}:ECSCluster"
@@ -255,6 +268,7 @@ Resources:
 
   TesterTaskDefinition:
     Type: 'AWS::ECS::TaskDefinition'
+    Condition: ShouldDeployTester
     Properties:
       ContainerDefinitions:
         - Name: "app"


### PR DESCRIPTION
*Description of changes:*

The TesterService is useful if you want to run it to make perpetual calls to the `/color` service to generate history. Because it generates a lot of requests, this can obfuscate what is happening when monitoring interactive demos (e.g., in CloudWatch and X-Ray). This PR makes deployment of the TesterService optional.

When deploying the `ecs-colorapp.yaml` stack, to also deploy the TesterService you will need to explicitly set the `DeployTester` parameter to "true", or when using the `ecs-colorapp.sh` deploy script, explicitly set the `DEPLOY_TESTER` environment variable to "true", as shown below:

```
DEPLOY_TESTER=true ./examples/apps/colorapp/ecs-colorapp.sh`
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
