### PR TITLE
Fix deploy script exit

### DIFF
--- a/examples/apps/colorapp/ecs/ecs-colorapp.sh
+++ b/examples/apps/colorapp/ecs/ecs-colorapp.sh
@@ -8,10 +8,6 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 # will deploy the TesterService, which perpetually invokes /color to generate history
 : "${DEPLOY_TESTER:='false'}"
 
-
-echo "DEPLOY_TESTER=${DEPLOY_TESTER}"
-exit
-
 # Creating Task Definitions
 source ${DIR}/create-task-defs.sh
 


### PR DESCRIPTION
*Description of changes:*
Remove early exit from `ecs-colorapp.sh`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
