### PR TITLE
remove quotes from default value

### DIFF
--- a/examples/apps/colorapp/ecs/ecs-colorapp.sh
+++ b/examples/apps/colorapp/ecs/ecs-colorapp.sh
@@ -6,7 +6,7 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 
 # ecs-colorapp.yaml expects "true" or "false" (default is "false")
 # will deploy the TesterService, which perpetually invokes /color to generate history
-: "${DEPLOY_TESTER:='false'}"
+: "${DEPLOY_TESTER:=false}"
 
 # Creating Task Definitions
 source ${DIR}/create-task-defs.sh


### PR DESCRIPTION
*Description of changes:*
Remove quotes from default parameter value for TesterService (causes it to fail cloudformation parameter check allowed values).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
