### PR TITLE
Changed TargetGroup health-check for gateway from /ping to /color

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .env*
 examples/apps/colorapp/pkg/
 examples/apps/colorapp/bin
+.DS_Store

--- a/examples/apps/colorapp/ecs/ecs-colorapp.yaml
+++ b/examples/apps/colorapp/ecs/ecs-colorapp.yaml
@@ -384,7 +384,7 @@ Resources:
     Type: AWS::ElasticLoadBalancingV2::TargetGroup
     Properties:
       HealthCheckIntervalSeconds: 6
-      HealthCheckPath: /ping
+      HealthCheckPath: /color
       HealthCheckProtocol: HTTP
       HealthCheckTimeoutSeconds: 5
       HealthyThresholdCount: 2


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Color Gateway health-checks fail because there is no ping handler. This causes ECS service to churn tasks out. This PR changes the health-check to use /color (deep-check), this should be okay for example app.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
