### PR TITLE
Statsd: Color App example that publishes metrics to AWS Cloud Watch metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .env*
 examples/apps/colorapp/pkg/
 examples/apps/colorapp/bin
+.DS_Store

--- a/NOTICE
+++ b/NOTICE
@@ -9,5 +9,6 @@ This software includes third party software subject to the following copyrights:
 - Istio iptables configuration and parameter names from https://github.com/istio/istio - Copyright 2016-2018 Istio Authors, licensed under Apache License 2.0.
 - Docker Alpine Infinite Loop Curl from https://github.com/tstrohmeier/docker-alpine-infinite-curl - Copyright (c) 2018 Donal Byrne & Thomas Strohmeier, licensed under the MIT license.
 - TCP echo server from https://github.com/cjimti/go-echo - Copyright (c) 2018 Craig Johnston, licensed under the MIT license.
+- Statsd to AWS CloudWatch sidecar from https://github.com/atlassian/gostatsd - Copyright (c) 2012 Kamil Kisiel, Copyright @ 2016 - 2017 Atlassian Pty Ltd and others, licensed under the MIT license.
 
 The licenses for these third party components are included in LICENSE

--- a/examples/README.md
+++ b/examples/README.md
@@ -22,6 +22,7 @@ export CLUSTER_SIZE=<number of ec2 instances to spin up to join cluster
 export SERVICES_DOMAIN=<domain under which services will be discovered, e.g. "default.svc.cluster.local">
 export COLOR_GATEWAY_IMAGE=<image location for colorapp's gateway, e.g. "<youraccountnumber>.dkr.ecr.amazonaws.com/gateway:latest" - you need to build this image and use your own ECR repository, see below>
 export COLOR_TELLER_IMAGE=<image location for colorapp's teller, e.g. "<youraccountnumber>.dkr.ecr.amazonaws.com/colorteller:latest" - you need to build this image and use your own ECR repository, see below>
+export STATSD_IMAGE=<image location for statsd sidecar, e.g. "<youraccountnumber>.dkr.ecr.amazonaws.com/statsd:latest" - you need to build this image and use your own ECR repository, see below>
 ```
 
 ## Infrastructure
@@ -64,6 +65,9 @@ In Elastic Container Registry, created two new repositories:
 
 Build the docker images as follow:
 ```
+cd apps/colorapp/src/statsd
+./deploy.sh
+cd -
 cd apps/colorapp/src/colorteller/
 ./deploy.sh
 cd -

--- a/examples/apps/colorapp/ecs/colorgateway-base-task-def.json
+++ b/examples/apps/colorapp/ecs/colorgateway-base-task-def.json
@@ -33,7 +33,6 @@
       "portMappings": [
         {
           "containerPort": 9080,
-          "hostPort": 9080,
           "protocol": "tcp"
         }
       ],
@@ -72,7 +71,8 @@
       ]
     },
     $ENVOY_CONTAINER_JSON,
-    $XRAY_CONTAINER_JSON
+    $XRAY_CONTAINER_JSON,
+    $STATSD_CONTAINER_JSON
   ],
   "taskRoleArn": $TASK_ROLE_ARN,
   "executionRoleArn": $EXECUTION_ROLE_ARN,

--- a/examples/apps/colorapp/ecs/colorteller-base-task-def.json
+++ b/examples/apps/colorapp/ecs/colorteller-base-task-def.json
@@ -33,7 +33,6 @@
       "portMappings": [
         {
           "containerPort": 9080,
-          "hostPort": 9080,
           "protocol": "tcp"
         }
       ],
@@ -68,7 +67,8 @@
       ]
     },
     $ENVOY_CONTAINER_JSON,
-    $XRAY_CONTAINER_JSON
+    $XRAY_CONTAINER_JSON,
+    $STATSD_CONTAINER_JSON
   ],
   "taskRoleArn": $TASK_ROLE_ARN,
   "executionRoleArn": $EXECUTION_ROLE_ARN,

--- a/examples/apps/colorapp/ecs/create-task-defs.sh
+++ b/examples/apps/colorapp/ecs/create-task-defs.sh
@@ -1,8 +1,28 @@
 #!/bin/bash
 
-# set -ex
+set -ex
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+
+if [ -z "${ENVOY_IMAGE}" ]; then
+    echo "ENVOY_IMAGE environment is not defined"
+    exit 1
+fi
+
+if [ -z "${STATSD_IMAGE}" ]; then
+    echo "STATSD_IMAGE environment is not defined"
+    exit 1
+fi
+
+if [ -z "${COLOR_GATEWAY_IMAGE}" ]; then
+    echo "COLOR_GATEWAY_IMAGE environment is not defined"
+    exit 1
+fi
+
+if [ -z "${COLOR_TELLER_IMAGE}" ]; then
+    echo "COLOR_TELLER_IMAGE environment is not defined"
+    exit 1
+fi
 
 stack_output=$(aws --profile "${AWS_PROFILE}" --region "${AWS_DEFAULT_REGION}" \
     cloudformation describe-stacks --stack-name "${ENVIRONMENT_NAME}-ecs-cluster" \
@@ -19,21 +39,68 @@ ecs_service_log_group=($(echo $stack_output \
 
 envoy_log_level="debug"
 
-# Color Gateway Task Definition
-envoy_container_json=$(jq -n \
+generate_statsd_container_json() {
+    app_name=$1
+    statsd_container_json=$(jq -n \
+    --arg STATSD_IMAGE $STATSD_IMAGE \
+    --arg ECS_SERVICE_LOG_GROUP $ecs_service_log_group \
+    --arg AWS_REGION $AWS_DEFAULT_REGION \
+    --arg AWS_LOG_STREAM_PREFIX "${app_name}-statsd" \
+    -f "${DIR}/statsd-container.json")
+}
+
+generate_xray_container_json() {
+    app_name=$1
+    xray_container_json=$(jq -n \
+    --arg ECS_SERVICE_LOG_GROUP $ecs_service_log_group \
+    --arg AWS_REGION $AWS_DEFAULT_REGION \
+    --arg AWS_LOG_STREAM_PREFIX "${app_name}-xray" \
+    -f "${DIR}/xray-container.json")
+}
+
+generate_envoy_container_json() {
+    app_name=$1
+    envoy_container_json=$(jq -n \
     --arg ENVOY_IMAGE $ENVOY_IMAGE \
-    --arg VIRTUAL_NODE "mesh/$MESH_NAME/virtualNode/colorgateway-vn" \
+    --arg VIRTUAL_NODE "mesh/$MESH_NAME/virtualNode/${app_name}-vn" \
     --arg APPMESH_XDS_ENDPOINT "${APPMESH_XDS_ENDPOINT}" \
     --arg ENVOY_LOG_LEVEL $envoy_log_level \
     --arg ECS_SERVICE_LOG_GROUP $ecs_service_log_group \
     --arg AWS_REGION $AWS_DEFAULT_REGION \
-    --arg AWS_LOG_STREAM_PREFIX_ENVOY "colorgateway-envoy" \
+    --arg AWS_LOG_STREAM_PREFIX "${app_name}-envoy" \
     -f "${DIR}/envoy-container.json")
-xray_container_json=$(jq -n \
-    --arg ECS_SERVICE_LOG_GROUP $ecs_service_log_group \
+}
+
+generate_sidecars() {
+    app_name=$1
+    generate_envoy_container_json ${app_name}
+    generate_xray_container_json ${app_name}
+    generate_statsd_container_json ${app_name}
+}
+
+generate_color_teller_task_def() {
+    color=$1
+    task_def_json=$(jq -n \
+    --arg NAME "$ENVIRONMENT_NAME-ColorTeller-${color}" \
+    --arg STAGE "$APPMESH_STAGE" \
+    --arg COLOR "${color}" \
+    --arg APP_IMAGE $COLOR_TELLER_IMAGE \
     --arg AWS_REGION $AWS_DEFAULT_REGION \
-    --arg AWS_LOG_STREAM_PREFIX_ENVOY "colorgateway-xray" \
-    -f "${DIR}/xray-container.json")
+    --arg ECS_SERVICE_LOG_GROUP $ecs_service_log_group \
+    --arg AWS_LOG_STREAM_PREFIX_APP "colorteller-${color}-app" \
+    --arg TASK_ROLE_ARN $task_role_arn \
+    --arg EXECUTION_ROLE_ARN $execution_role_arn \
+    --argjson ENVOY_CONTAINER_JSON "${envoy_container_json}" \
+    --argjson XRAY_CONTAINER_JSON "${xray_container_json}" \
+    --argjson STATSD_CONTAINER_JSON "${statsd_container_json}" \
+    -f "${DIR}/colorteller-base-task-def.json")
+    task_def=$(aws --profile "${AWS_PROFILE}" --region "${AWS_DEFAULT_REGION}" \
+    ecs register-task-definition \
+    --cli-input-json "$task_def_json")
+}
+
+# Color Gateway Task Definition
+generate_sidecars "colorgateway"
 task_def_json=$(jq -n \
     --arg NAME "$ENVIRONMENT_NAME-ColorGateway" \
     --arg STAGE "$APPMESH_STAGE" \
@@ -47,6 +114,7 @@ task_def_json=$(jq -n \
     --arg EXECUTION_ROLE_ARN $execution_role_arn \
     --argjson ENVOY_CONTAINER_JSON "${envoy_container_json}" \
     --argjson XRAY_CONTAINER_JSON "${xray_container_json}" \
+    --argjson STATSD_CONTAINER_JSON "${statsd_container_json}" \
     -f "${DIR}/colorgateway-base-task-def.json")
 task_def=$(aws --profile "${AWS_PROFILE}" --region "${AWS_DEFAULT_REGION}" \
     ecs register-task-definition \
@@ -55,138 +123,27 @@ colorgateway_task_def_arn=($(echo $task_def \
     | jq -r '.taskDefinition | .taskDefinitionArn'))
 
 # Color Teller White Task Definition
-envoy_container_json=$(jq -n \
-    --arg ENVOY_IMAGE $ENVOY_IMAGE \
-    --arg VIRTUAL_NODE "mesh/$MESH_NAME/virtualNode/colorteller-white-vn" \
-    --arg APPMESH_XDS_ENDPOINT "${APPMESH_XDS_ENDPOINT}" \
-    --arg ENVOY_LOG_LEVEL $envoy_log_level \
-    --arg ECS_SERVICE_LOG_GROUP $ecs_service_log_group \
-    --arg AWS_REGION $AWS_DEFAULT_REGION \
-    --arg AWS_LOG_STREAM_PREFIX_ENVOY "colorteller-white-envoy" \
-    -f "${DIR}/envoy-container.json")
-xray_container_json=$(jq -n \
-    --arg ECS_SERVICE_LOG_GROUP $ecs_service_log_group \
-    --arg AWS_REGION $AWS_DEFAULT_REGION \
-    --arg AWS_LOG_STREAM_PREFIX_ENVOY "colorteller-white-xray" \
-    -f "${DIR}/xray-container.json")
-task_def_json=$(jq -n \
-    --arg NAME "$ENVIRONMENT_NAME-ColorTellerWhite" \
-    --arg STAGE "$APPMESH_STAGE" \
-    --arg COLOR "white" \
-    --arg APP_IMAGE $COLOR_TELLER_IMAGE \
-    --arg AWS_REGION $AWS_DEFAULT_REGION \
-    --arg ECS_SERVICE_LOG_GROUP $ecs_service_log_group \
-    --arg AWS_LOG_STREAM_PREFIX_APP "colorteller-white-app" \
-    --arg TASK_ROLE_ARN $task_role_arn \
-    --arg EXECUTION_ROLE_ARN $execution_role_arn \
-    --argjson ENVOY_CONTAINER_JSON "${envoy_container_json}" \
-    --argjson XRAY_CONTAINER_JSON "${xray_container_json}" \
-    -f "${DIR}/colorteller-base-task-def.json")
-task_def=$(aws --profile "${AWS_PROFILE}" --region "${AWS_DEFAULT_REGION}" \
-    ecs register-task-definition \
-    --cli-input-json "$task_def_json")
+generate_sidecars "colorteller-white"
+generate_color_teller_task_def "white"
 colorteller_white_task_def_arn=($(echo $task_def \
     | jq -r '.taskDefinition | .taskDefinitionArn'))
 
 # Color Teller Red Task Definition
-envoy_container_json=$(jq -n \
-    --arg ENVOY_IMAGE $ENVOY_IMAGE \
-    --arg VIRTUAL_NODE "mesh/$MESH_NAME/virtualNode/colorteller-red-vn" \
-    --arg APPMESH_XDS_ENDPOINT "${APPMESH_XDS_ENDPOINT}" \
-    --arg ENVOY_LOG_LEVEL $envoy_log_level \
-    --arg ECS_SERVICE_LOG_GROUP $ecs_service_log_group \
-    --arg AWS_REGION $AWS_DEFAULT_REGION \
-    --arg AWS_LOG_STREAM_PREFIX_ENVOY "colorteller-red-envoy" \
-    -f "${DIR}/envoy-container.json")
-xray_container_json=$(jq -n \
-    --arg ECS_SERVICE_LOG_GROUP $ecs_service_log_group \
-    --arg AWS_REGION $AWS_DEFAULT_REGION \
-    --arg AWS_LOG_STREAM_PREFIX_ENVOY "colorteller-red-xray" \
-    -f "${DIR}/xray-container.json")
-task_def_json=$(jq -n \
-    --arg NAME "$ENVIRONMENT_NAME-ColorTellerRed" \
-    --arg STAGE "$APPMESH_STAGE" \
-    --arg COLOR "red" \
-    --arg APP_IMAGE $COLOR_TELLER_IMAGE \
-    --arg AWS_REGION $AWS_DEFAULT_REGION \
-    --arg ECS_SERVICE_LOG_GROUP $ecs_service_log_group \
-    --arg AWS_LOG_STREAM_PREFIX_APP "colorteller-red-app" \
-    --arg TASK_ROLE_ARN $task_role_arn \
-    --arg EXECUTION_ROLE_ARN $execution_role_arn \
-    --argjson ENVOY_CONTAINER_JSON "${envoy_container_json}" \
-    --argjson XRAY_CONTAINER_JSON "${xray_container_json}" \
-    -f "${DIR}/colorteller-base-task-def.json")
-task_def=$(aws --profile "${AWS_PROFILE}" --region "${AWS_DEFAULT_REGION}" \
-    ecs register-task-definition \
-    --cli-input-json "$task_def_json")
+generate_sidecars "colorteller-red"
+generate_color_teller_task_def "red"
 colorteller_red_task_def_arn=($(echo $task_def \
     | jq -r '.taskDefinition | .taskDefinitionArn'))
 
 # Color Teller Blue Task Definition
-envoy_container_json=$(jq -n \
-    --arg ENVOY_IMAGE $ENVOY_IMAGE \
-    --arg VIRTUAL_NODE "mesh/$MESH_NAME/virtualNode/colorteller-blue-vn" \
-    --arg APPMESH_XDS_ENDPOINT "${APPMESH_XDS_ENDPOINT}" \
-    --arg ENVOY_LOG_LEVEL $envoy_log_level \
-    --arg ECS_SERVICE_LOG_GROUP $ecs_service_log_group \
-    --arg AWS_REGION $AWS_DEFAULT_REGION \
-    --arg AWS_LOG_STREAM_PREFIX_ENVOY "colorteller-blue-envoy" \
-    -f "${DIR}/envoy-container.json")
-xray_container_json=$(jq -n \
-    --arg ECS_SERVICE_LOG_GROUP $ecs_service_log_group \
-    --arg AWS_REGION $AWS_DEFAULT_REGION \
-    --arg AWS_LOG_STREAM_PREFIX_ENVOY "colorteller-blue-xray" \
-    -f "${DIR}/xray-container.json")    
-task_def_json=$(jq -n \
-    --arg NAME "$ENVIRONMENT_NAME-ColorTellerBlue" \
-    --arg STAGE "$APPMESH_STAGE" \
-    --arg COLOR "blue" \
-    --arg APP_IMAGE $COLOR_TELLER_IMAGE \
-    --arg AWS_REGION $AWS_DEFAULT_REGION \
-    --arg ECS_SERVICE_LOG_GROUP $ecs_service_log_group \
-    --arg AWS_LOG_STREAM_PREFIX_APP "colorteller-blue-app" \
-    --arg TASK_ROLE_ARN $task_role_arn \
-    --arg EXECUTION_ROLE_ARN $execution_role_arn \
-    --argjson ENVOY_CONTAINER_JSON "${envoy_container_json}" \
-    --argjson XRAY_CONTAINER_JSON "${xray_container_json}" \
-    -f "${DIR}/colorteller-base-task-def.json")
-task_def=$(aws --profile "${AWS_PROFILE}" --region "${AWS_DEFAULT_REGION}" \
-    ecs register-task-definition \
-    --cli-input-json "$task_def_json")
+generate_sidecars "colorteller-blue"
+generate_color_teller_task_def "blue"
 colorteller_blue_task_def_arn=($(echo $task_def \
     | jq -r '.taskDefinition | .taskDefinitionArn'))
 
 # Color Teller Black Task Definition
-envoy_container_json=$(jq -n \
-    --arg ENVOY_IMAGE $ENVOY_IMAGE \
-    --arg VIRTUAL_NODE "mesh/$MESH_NAME/virtualNode/colorteller-black-vn" \
-    --arg APPMESH_XDS_ENDPOINT "${APPMESH_XDS_ENDPOINT}" \
-    --arg ENVOY_LOG_LEVEL $envoy_log_level \
-    --arg ECS_SERVICE_LOG_GROUP $ecs_service_log_group \
-    --arg AWS_REGION $AWS_DEFAULT_REGION \
-    --arg AWS_LOG_STREAM_PREFIX_ENVOY "colorteller-black-envoy" \
-    -f "${DIR}/envoy-container.json")
-xray_container_json=$(jq -n \
-    --arg ECS_SERVICE_LOG_GROUP $ecs_service_log_group \
-    --arg AWS_REGION $AWS_DEFAULT_REGION \
-    --arg AWS_LOG_STREAM_PREFIX_ENVOY "colorteller-black-xray" \
-    -f "${DIR}/xray-container.json")    
-task_def_json=$(jq -n \
-    --arg NAME "$ENVIRONMENT_NAME-ColorTellerBlack" \
-    --arg STAGE "$APPMESH_STAGE" \
-    --arg COLOR "black" \
-    --arg APP_IMAGE $COLOR_TELLER_IMAGE \
-    --arg AWS_REGION $AWS_DEFAULT_REGION \
-    --arg ECS_SERVICE_LOG_GROUP $ecs_service_log_group \
-    --arg AWS_LOG_STREAM_PREFIX_APP "colorteller-black-app" \
-    --arg TASK_ROLE_ARN $task_role_arn \
-    --arg EXECUTION_ROLE_ARN $execution_role_arn \
-    --argjson ENVOY_CONTAINER_JSON "${envoy_container_json}" \
-    --argjson XRAY_CONTAINER_JSON "${xray_container_json}" \
-    -f "${DIR}/colorteller-base-task-def.json")
-task_def=$(aws --profile "${AWS_PROFILE}" --region "${AWS_DEFAULT_REGION}" \
-    ecs register-task-definition \
-    --cli-input-json "$task_def_json")
+generate_sidecars "colorteller-black"
+generate_color_teller_task_def "black"
 colorteller_black_task_def_arn=($(echo $task_def \
     | jq -r '.taskDefinition | .taskDefinitionArn'))
 
+echo "Created task-definitions with Envoy, X-Ray and Statsd"

--- a/examples/apps/colorapp/ecs/ecs-colorapp.sh
+++ b/examples/apps/colorapp/ecs/ecs-colorapp.sh
@@ -8,10 +8,6 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 # will deploy the TesterService, which perpetually invokes /color to generate history
 : "${DEPLOY_TESTER:='false'}"
 
-
-echo "DEPLOY_TESTER=${DEPLOY_TESTER}"
-exit
-
 # Creating Task Definitions
 source ${DIR}/create-task-defs.sh
 

--- a/examples/apps/colorapp/ecs/ecs-colorapp.sh
+++ b/examples/apps/colorapp/ecs/ecs-colorapp.sh
@@ -6,7 +6,7 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 
 # ecs-colorapp.yaml expects "true" or "false" (default is "false")
 # will deploy the TesterService, which perpetually invokes /color to generate history
-: "${DEPLOY_TESTER:='false'}"
+: "${DEPLOY_TESTER:=false}"
 
 # Creating Task Definitions
 source ${DIR}/create-task-defs.sh

--- a/examples/apps/colorapp/ecs/envoy-container.json
+++ b/examples/apps/colorapp/ecs/envoy-container.json
@@ -13,17 +13,14 @@
   "portMappings": [
     {
       "containerPort": 9901,
-      "hostPort": 9901,
       "protocol": "tcp"
     },
     {
       "containerPort": 15000,
-      "hostPort": 15000,
       "protocol": "tcp"
     },
     {
       "containerPort": 15001,
-      "hostPort": 15001,
       "protocol": "tcp"
     }
   ],
@@ -47,6 +44,10 @@
     {
       "name": "ENABLE_ENVOY_STATS_TAGS",
       "value": "1"
+    },
+    {
+      "name": "ENABLE_ENVOY_DOG_STATSD",
+      "value": "1"
     }
   ],
   "logConfiguration": {
@@ -54,7 +55,7 @@
     "options": {
       "awslogs-group": $ECS_SERVICE_LOG_GROUP,
       "awslogs-region": $AWS_REGION,
-      "awslogs-stream-prefix": $AWS_LOG_STREAM_PREFIX_ENVOY
+      "awslogs-stream-prefix": $AWS_LOG_STREAM_PREFIX
     }
   },
   "healthCheck": {

--- a/examples/apps/colorapp/ecs/statsd-container.json
+++ b/examples/apps/colorapp/ecs/statsd-container.json
@@ -1,14 +1,22 @@
 {
-  "name": "xray-daemon",
-  "image": "amazon/aws-xray-daemon",
+  "name": "statsd",
+  "image": $STATSD_IMAGE,
   "user": "1337",
   "essential": true,
-  "cpu": 32,
-  "memoryReservation": 256,
   "portMappings": [
     {
-      "containerPort": 2000,
+      "containerPort": 8125,
       "protocol": "udp"
+    }
+  ],
+  "environment": [
+    {
+      "name": "AWS_REGION",
+      "value": $AWS_REGION
+    },
+    {
+      "name": "CLOUDWATCH_NAMESPACE",
+      "value": "ColorApp"
     }
   ],
   "logConfiguration": {

--- a/examples/apps/colorapp/src/statsd/Dockerfile
+++ b/examples/apps/colorapp/src/statsd/Dockerfile
@@ -1,0 +1,5 @@
+FROM atlassianlabs/gostatsd
+
+COPY gostatsd_wrapper /bin/gostatsd_wrapper
+
+ENTRYPOINT ["gostatsd_wrapper"]

--- a/examples/apps/colorapp/src/statsd/deploy.sh
+++ b/examples/apps/colorapp/src/statsd/deploy.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# vim:syn=sh:ts=4:sw=4:et:ai
+
+set -ex
+
+if [ -z $STATSD_IMAGE ]; then
+    echo "STATSD_IMAGE environment variable is not set"
+    exit 1
+fi
+
+# build
+docker build -t $STATSD_IMAGE .
+
+# push
+if [ -z $AWS_PROFILE  ]; then
+    $(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION)
+else
+    $(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION --profile $AWS_PROFILE)
+fi
+docker push $STATSD_IMAGE

--- a/examples/apps/colorapp/src/statsd/gostatsd_wrapper
+++ b/examples/apps/colorapp/src/statsd/gostatsd_wrapper
@@ -1,0 +1,10 @@
+#!/bin/sh -e
+
+CONFIG_FILE="/tmp/cloudwatch_config.toml"
+
+cat << CONFIG_EOF > "${CONFIG_FILE}"
+[cloudwatch]
+    namespace = "${CLOUDWATCH_NAMESPACE:-Statsd}"
+CONFIG_EOF
+
+exec /bin/gostatsd --backends cloudwatch --config-path ${CONFIG_FILE}


### PR DESCRIPTION
> Warning: Did not do any cost analysis of Cloud Watch metrics for this example, so use it for testing purposes

*Issue #, if available:*
Related to #95 

*Description of changes:*
Color App example that publishes metrics to AWS Cloud Watch metrics.
- Uses https://github.com/atlassian/gostatsd as statsd sidecar and forwards metrics to Cloud Watch

*TODO*
- Provide a Cloud Watch dashboard template.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
