### PR TITLE
Color App example that publishes metrics to AWS Cloud Watch metrics

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -9,5 +9,6 @@ This software includes third party software subject to the following copyrights:
 - Istio iptables configuration and parameter names from https://github.com/istio/istio - Copyright 2016-2018 Istio Authors, licensed under Apache License 2.0.
 - Docker Alpine Infinite Loop Curl from https://github.com/tstrohmeier/docker-alpine-infinite-curl - Copyright (c) 2018 Donal Byrne & Thomas Strohmeier, licensed under the MIT license.
 - TCP echo server from https://github.com/cjimti/go-echo - Copyright (c) 2018 Craig Johnston, licensed under the MIT license.
+- Statsd to AWS CloudWatch sidecar from https://github.com/atlassian/gostatsd - Copyright (c) 2012 Kamil Kisiel, Copyright @ 2016 - 2017 Atlassian Pty Ltd and others, licensed under the MIT license.
 
 The licenses for these third party components are included in LICENSE

--- a/examples/README.md
+++ b/examples/README.md
@@ -22,6 +22,7 @@ export CLUSTER_SIZE=<number of ec2 instances to spin up to join cluster
 export SERVICES_DOMAIN=<domain under which services will be discovered, e.g. "default.svc.cluster.local">
 export COLOR_GATEWAY_IMAGE=<image location for colorapp's gateway, e.g. "<youraccountnumber>.dkr.ecr.amazonaws.com/gateway:latest" - you need to build this image and use your own ECR repository, see below>
 export COLOR_TELLER_IMAGE=<image location for colorapp's teller, e.g. "<youraccountnumber>.dkr.ecr.amazonaws.com/colorteller:latest" - you need to build this image and use your own ECR repository, see below>
+export STATSD_IMAGE=<image location for statsd sidecar, e.g. "<youraccountnumber>.dkr.ecr.amazonaws.com/statsd:latest" - you need to build this image and use your own ECR repository, see below>
 ```
 
 ## Infrastructure
@@ -64,6 +65,9 @@ In Elastic Container Registry, created two new repositories:
 
 Build the docker images as follow:
 ```
+cd apps/colorapp/src/statsd
+./deploy.sh
+cd -
 cd apps/colorapp/src/colorteller/
 ./deploy.sh
 cd -

--- a/examples/apps/colorapp/ecs/colorgateway-base-task-def.json
+++ b/examples/apps/colorapp/ecs/colorgateway-base-task-def.json
@@ -33,7 +33,6 @@
       "portMappings": [
         {
           "containerPort": 9080,
-          "hostPort": 9080,
           "protocol": "tcp"
         }
       ],
@@ -72,7 +71,8 @@
       ]
     },
     $ENVOY_CONTAINER_JSON,
-    $XRAY_CONTAINER_JSON
+    $XRAY_CONTAINER_JSON,
+    $STATSD_CONTAINER_JSON
   ],
   "taskRoleArn": $TASK_ROLE_ARN,
   "executionRoleArn": $EXECUTION_ROLE_ARN,

--- a/examples/apps/colorapp/ecs/colorteller-base-task-def.json
+++ b/examples/apps/colorapp/ecs/colorteller-base-task-def.json
@@ -33,7 +33,6 @@
       "portMappings": [
         {
           "containerPort": 9080,
-          "hostPort": 9080,
           "protocol": "tcp"
         }
       ],
@@ -68,7 +67,8 @@
       ]
     },
     $ENVOY_CONTAINER_JSON,
-    $XRAY_CONTAINER_JSON
+    $XRAY_CONTAINER_JSON,
+    $STATSD_CONTAINER_JSON
   ],
   "taskRoleArn": $TASK_ROLE_ARN,
   "executionRoleArn": $EXECUTION_ROLE_ARN,

--- a/examples/apps/colorapp/ecs/envoy-container.json
+++ b/examples/apps/colorapp/ecs/envoy-container.json
@@ -13,17 +13,14 @@
   "portMappings": [
     {
       "containerPort": 9901,
-      "hostPort": 9901,
       "protocol": "tcp"
     },
     {
       "containerPort": 15000,
-      "hostPort": 15000,
       "protocol": "tcp"
     },
     {
       "containerPort": 15001,
-      "hostPort": 15001,
       "protocol": "tcp"
     }
   ],
@@ -47,6 +44,10 @@
     {
       "name": "ENABLE_ENVOY_STATS_TAGS",
       "value": "1"
+    },
+    {
+      "name": "ENABLE_ENVOY_DOG_STATSD",
+      "value": "1"
     }
   ],
   "logConfiguration": {
@@ -54,7 +55,7 @@
     "options": {
       "awslogs-group": $ECS_SERVICE_LOG_GROUP,
       "awslogs-region": $AWS_REGION,
-      "awslogs-stream-prefix": $AWS_LOG_STREAM_PREFIX_ENVOY
+      "awslogs-stream-prefix": $AWS_LOG_STREAM_PREFIX
     }
   },
   "healthCheck": {

--- a/examples/apps/colorapp/ecs/statsd-container.json
+++ b/examples/apps/colorapp/ecs/statsd-container.json
@@ -1,14 +1,22 @@
 {
-  "name": "xray-daemon",
-  "image": "amazon/aws-xray-daemon",
+  "name": "statsd",
+  "image": $STATSD_IMAGE,
   "user": "1337",
   "essential": true,
-  "cpu": 32,
-  "memoryReservation": 256,
   "portMappings": [
     {
-      "containerPort": 2000,
+      "containerPort": 8125,
       "protocol": "udp"
+    }
+  ],
+  "environment": [
+    {
+      "name": "AWS_REGION",
+      "value": $AWS_REGION
+    },
+    {
+      "name": "CLOUDWATCH_NAMESPACE",
+      "value": "ColorApp"
     }
   ],
   "logConfiguration": {

--- a/examples/apps/colorapp/src/statsd/Dockerfile
+++ b/examples/apps/colorapp/src/statsd/Dockerfile
@@ -1,0 +1,5 @@
+FROM atlassianlabs/gostatsd
+
+COPY gostatsd_wrapper /bin/gostatsd_wrapper
+
+ENTRYPOINT ["gostatsd_wrapper"]

--- a/examples/apps/colorapp/src/statsd/deploy.sh
+++ b/examples/apps/colorapp/src/statsd/deploy.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# vim:syn=sh:ts=4:sw=4:et:ai
+
+set -ex
+
+if [ -z $STATSD_IMAGE ]; then
+    echo "STATSD_IMAGE environment variable is not set"
+    exit 1
+fi
+
+# build
+docker build -t $STATSD_IMAGE .
+
+# push
+if [ -z $AWS_PROFILE  ]; then
+    $(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION)
+else
+    $(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION --profile $AWS_PROFILE)
+fi
+docker push $STATSD_IMAGE

--- a/examples/apps/colorapp/src/statsd/gostatsd_wrapper
+++ b/examples/apps/colorapp/src/statsd/gostatsd_wrapper
@@ -1,0 +1,10 @@
+#!/bin/sh -e
+
+CONFIG_FILE="/tmp/cloudwatch_config.toml"
+
+cat << CONFIG_EOF > "${CONFIG_FILE}"
+[cloudwatch]
+    namespace = "${CLOUDWATCH_NAMESPACE:-Statsd}"
+CONFIG_EOF
+
+exec /bin/gostatsd --backends cloudwatch --config-path ${CONFIG_FILE}


### PR DESCRIPTION
*Issue #, if available:*
#95 

*Description of changes:*
- Uses https://github.com/atlassian/gostatsd as statsd sidecar and
forwards metrics to Cloud Watch

> Warning: Did not do any cost analysis of Cloud Watch metrics for this
> example, so use it for testing purposes.

TODO:
- Provide a Cloud Watch dashboard template.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
