### PR TITLE
Add note to install aws-iam-authenticator

### DIFF
--- a/walkthroughs/eks/base.md
+++ b/walkthroughs/eks/base.md
@@ -8,7 +8,8 @@ In order to successfully carry out the base deployment:
 
 - Make sure to have newest [AWS CLI](https://aws.amazon.com/cli/) installed, that is, version `1.16.124` or above.
 - Make sure to have `kubectl` [installed](https://kubernetes.io/docs/tasks/tools/install-kubectl/), at least version `1.11` or above.
-- Make sure that to have `jq` [installed](https://stedolan.github.io/jq/download/).
+- Make sure to have `jq` [installed](https://stedolan.github.io/jq/download/).
+- Make sure to have `aws-iam-authenticator` [installed](https://github.com/kubernetes-sigs/aws-iam-authenticator), required for eksctl
 - Install [eksctl](https://eksctl.io/), for example, on macOS with `brew tap weaveworks/tap` and `brew install weaveworks/tap/eksctl`, and make sure it's on at least on version `0.1.26`.
 
 Note that this walkthrough assumes throughout to operate in the `us-east-2` region.


### PR DESCRIPTION
The walk through didn't specify this needed to be installed although eksctl requires it or `heptio-authenticator-aws`

*Description of changes:*
Also fixed grammar on line above
