### PR TITLE
Updated AWS_LOG_STREAM_PREFIX_ENVOY to AWS_LOG_STREAM_PREFIX in walkthrough.

### DIFF
--- a/walkthroughs/fargate/fargate-colorteller-task-def.sh
+++ b/walkthroughs/fargate/fargate-colorteller-task-def.sh
@@ -28,7 +28,7 @@ envoy_container_json=$(jq -n \
     --arg ENVOY_LOG_LEVEL $envoy_log_level \
     --arg ECS_SERVICE_LOG_GROUP $ecs_service_log_group \
     --arg AWS_REGION $AWS_DEFAULT_REGION \
-    --arg AWS_LOG_STREAM_PREFIX_ENVOY "colorteller-$COLOR-envoy" \
+    --arg AWS_LOG_STREAM_PREFIX "colorteller-$COLOR-envoy" \
     -f "${DIR}/envoy-container.json")
 xray_container_json=$(jq -n \
     --arg ECS_SERVICE_LOG_GROUP $ecs_service_log_group \


### PR DESCRIPTION
AWS_LOG_STREAM_PREFIX_ENVOY is not defined when running fargate-colorteller-task-def.sh
The argument should be AWS_LOG_STREAM_PREFIX instead of AWS_LOG_STREAM_PREFIX_ENVOY
Same issue as #147 (in fargate walkthorugh)

*Description of changes:*
Updated AWS_LOG_STREAM_PREFIX_ENVOY to AWS_LOG_STREAM_PREFIX in walkthrough.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
