### PR TITLE
Drop Envoy Log Level to Debug for Cloud Map example

### DIFF
--- a/walkthroughs/howto-servicediscovery-cloudmap/app.yaml
+++ b/walkthroughs/howto-servicediscovery-cloudmap/app.yaml
@@ -244,7 +244,7 @@ Resources:
         - Name: 'APPMESH_VIRTUAL_NODE_NAME'
           Value: !Sub 'mesh/${AWS::StackName}-mesh/virtualNode/colorgateway-node'
         - Name: 'ENVOY_LOG_LEVEL'
-          Value: 'trace'
+          Value: 'debug'
 
   BlueColorTellerTaskDefinition:
     Type: AWS::ECS::TaskDefinition
@@ -326,7 +326,7 @@ Resources:
         - Name: 'APPMESH_VIRTUAL_NODE_NAME'
           Value: !Sub 'mesh/${AWS::StackName}-mesh/virtualNode/colorteller-blue-node'
         - Name: 'ENVOY_LOG_LEVEL'
-          Value: 'trace'
+          Value: 'debug'
 
   GreenColorTellerTaskDefinition:
     Type: AWS::ECS::TaskDefinition
@@ -408,7 +408,7 @@ Resources:
         - Name: 'APPMESH_VIRTUAL_NODE_NAME'
           Value: !Sub 'mesh/${AWS::StackName}-mesh/virtualNode/colorteller-green-node'
         - Name: 'ENVOY_LOG_LEVEL'
-          Value: 'trace'
+          Value: 'debug'
 
   ColorGatewayService:
     Type: AWS::ECS::Service


### PR DESCRIPTION
To reduce noise. The `debug` level should be sufficient to debug any issues.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
