### PR TITLE
specify path for update route, preview is only in one region, add ste…

### DIFF
--- a/walkthroughs/http-headers-and-priority/README.md
+++ b/walkthroughs/http-headers-and-priority/README.md
@@ -10,9 +10,9 @@
     export AWS_ACCOUNT_ID=<your_account_id>
     ```
 
-3. The region to use.
+3. Preview is only in us-west-2
     ```
-    export AWS_DEFAULT_REGION=<i.e. us-east-1>
+    export AWS_DEFAULT_REGION=us-west-2
     ```
 
 ## Create a VPC
@@ -116,7 +116,7 @@ aws cloudformation describe-stacks --stack-name header
 
 2. Update various routes with the json files in this package in order to see headers and priority updates. For instance in the demo video we change the priority of color-route-red by updating the *priority* value from 5 to 1 then running the following command 
   ```
-  aws appmesh-preview update-route --mesh-name header-mesh --cli-input-json file://red-route.json
+  aws appmesh-preview update-route --mesh-name header-mesh --cli-input-json file://components/red-route.json
   ```
 
 3. You will see the updated priority in the response json from the update-route command above to confirm your updates to the route. Try updating various color nodes with different headers and repeat the steps above to apply changes.
@@ -138,3 +138,5 @@ You can also delete the 2 stack we created with:
   ```
   aws cloudformation delete-stack --stack-name vpc
   ```
+  
+ delete the colorapp and feapp repositories in ECR through the console. Select each one and select delete.


### PR DESCRIPTION
…p to clean up

*Issue #, if available:*

*Description of changes:*
red-route file is located in components directory, preview is only in us-west-2 right now, remind customers to remove repositories in ECR

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
