### PR TITLE
Pull App Mesh regions from SSM

### DIFF
--- a/examples/apps/colorapp/servicemesh/.region-config.sh
+++ b/examples/apps/colorapp/servicemesh/.region-config.sh
@@ -1,18 +1,11 @@
-SUPPORTED_REGIONS=(\
-    ap-south-1 \
-    ap-northeast-3 \
-    ap-northeast-2 \
-    ap-northeast-1 \
-    ap-southeast-2 \
-    ap-southeast-1 \
-    ca-central-1 \
-    eu-central-1 \
-    eu-west-1 \
-    eu-west-2 \
-    us-east-1 \
-    us-east-2 \
-    us-west-1 \
-    us-west-2
-    )
+
+regions=$(aws --profile "${AWS_PROFILE}" --region "${AWS_DEFAULT_REGION}" --output text \
+  ssm get-parameters-by-path \
+  --path /aws/service/global-infrastructure/services/appmesh/regions \
+  --query 'Parameters[].Value')
+
+# convert tab-delimited response into array
+SUPPORTED_REGIONS=($(echo $regions | tr '\t' ' '))
 
 DEFAULT_REGION=us-west-2
+


### PR DESCRIPTION
*Description of changes:*

Per https://docs.aws.amazon.com/general/latest/gr/rande.html and https://docs.aws.amazon.com/systems-manager/latest/userguide/parameter-store-public-parameters.html#parameter-store-public-parameters-global-infrastructure retrieves App Mesh regions from SSM.

Verifying the region list:

```
% aws --profile "${AWS_PROFILE}" --region "${AWS_DEFAULT_REGION}" --output text \
  ssm get-parameters-by-path \
  --path /aws/service/global-infrastructure/services/appmesh/regions \
  --query 'Parameters[].Value'
ap-northeast-2	ap-south-1	ap-southeast-1	ap-southeast-2	ca-central-1	eu-west-1	eu-west-2	us-east-1	us-east-2	us-west-1
ap-northeast-1	eu-central-1	us-west-2
```

Checking behavior of change in the `.../colorapp/servicemesh directory`:

```
% AWS_DEFAULT_REGION=eu-west-3 ./route_canary.sh
[MESH] [Mon Aug 26 16:20:05 PDT 2019] : Error: Region eu-west-3 is not supported at this time (Supported regions: ap-northeast-1 ap-northeast-2 ap-south-1 ap-southeast-1 ap-southeast-2 ca-central-1 eu-west-1 us-east-1 us-east-2 us-west-1 eu-central-1 eu-west-2 us-west-2)
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
