### PR TITLE
TLS Walkthrough Fixes

### DIFF
--- a/walkthroughs/tls-with-acm/README.md
+++ b/walkthroughs/tls-with-acm/README.md
@@ -26,16 +26,18 @@ Additionally, this walkthrough makes use of the unix command line utility `jq`. 
 
 We'll start by setting up the basic infrastructure for our services. All commands will be provided as if run from the same directory as this README.
 
+You'll need a keypair stored in AWS to access a bastion host. If you don't have one, see [Amazon EC2 Key Pairs](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html).
+
 ```bash
 export AWS_ACCOUNT_ID=<your account id>
 export KEY_PAIR_NAME=<your SSH key pair stored in AWS>
 export AWS_DEFAULT_REGION=us-west-2
 export ENVIRONMENT_NAME=AppMeshTLSExample
 export MESH_NAME=ColorApp-TLS
-export ENVOY_IMAGE="111345817488.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-envoy:v1.11.1.1-prod"
+export ENVOY_IMAGE=<get the latest from https://docs.aws.amazon.com/app-mesh/latest/userguide/envoy.html>
 export SERVICES_DOMAIN="default.svc.cluster.local"
-export COLOR_GATEWAY_IMAGE="${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/gateway:latest"
-export COLOR_TELLER_IMAGE="${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/colorteller:latest"
+export GATEWAY_IMAGE_NAME="gateway"
+export COLOR_TELLER_IMAGE_NAME="colorteller"
 ```
 
 First, create the VPC.

--- a/walkthroughs/tls-with-acm/README.md
+++ b/walkthroughs/tls-with-acm/README.md
@@ -98,7 +98,7 @@ ROOT_CA_CERT_ARN=`aws acm-pca issue-certificate \
     --template-arn arn:aws:acm-pca:::template/RootCACertificate/V1 \
     --signing-algorithm SHA256WITHRSA \
     --validity Value=10,Type=YEARS \
-    --csr ${ROOT_CA_CSR} \
+    --csr "${ROOT_CA_CSR}" \
     --query CertificateArn --output text`
 ```
 
@@ -112,7 +112,7 @@ ROOT_CA_CERT=`aws acm-pca get-certificate \
 
 aws acm-pca import-certificate-authority-certificate \
     --certificate-authority-arn $ROOT_CA_ARN \
-    --certificate $ROOT_CA_CERT
+    --certificate "${ROOT_CA_CERT}"
 ```
 
 Now you can request a managed certificate from ACM using this CA:

--- a/walkthroughs/tls-with-acm/infrastructure/ecr-repositories.sh
+++ b/walkthroughs/tls-with-acm/infrastructure/ecr-repositories.sh
@@ -8,4 +8,7 @@ aws --profile "${AWS_PROFILE}" --region "${AWS_DEFAULT_REGION}" \
     cloudformation deploy \
     --stack-name "${ENVIRONMENT_NAME}-ecr-repositories" \
     --capabilities CAPABILITY_IAM \
-    --template-file "${DIR}/ecr-repositories.yaml"
+    --template-file "${DIR}/ecr-repositories.yaml" \
+    --parameter-overrides \
+    GatewayImageName="${GATEWAY_IMAGE_NAME}" \
+    ColorTellerImageName="${COLOR_TELLER_IMAGE_NAME}"

--- a/walkthroughs/tls-with-acm/infrastructure/ecr-repositories.yaml
+++ b/walkthroughs/tls-with-acm/infrastructure/ecr-repositories.yaml
@@ -1,10 +1,21 @@
+Parameters:
+
+  GatewayImageName:
+    Description: The name for the gateway image
+    Type: String
+
+  ColorTellerImageName:
+    Description: The name for the color teller image
+    Type: String
+
+
 Resources:
   GatewayRepository:
     Type: AWS::ECR::Repository
     Properties:
-      RepositoryName: gateway
+      RepositoryName: !Ref GatewayImageName
 
   ColorTellerRepository:
     Type: AWS::ECR::Repository
     Properties:
-      RepositoryName: colorteller
+      RepositoryName: !Ref ColorTellerImageName

--- a/walkthroughs/tls-with-acm/infrastructure/ecs-service.sh
+++ b/walkthroughs/tls-with-acm/infrastructure/ecs-service.sh
@@ -12,4 +12,7 @@ aws --profile "${AWS_PROFILE}" --region "${AWS_DEFAULT_REGION}" \
     --parameter-overrides \
     EnvironmentName="${ENVIRONMENT_NAME}" \
     ECSServicesDomain="${SERVICES_DOMAIN}" \
-    AppMeshMeshName="${MESH_NAME}"
+    AppMeshMeshName="${MESH_NAME}" \
+    EnvoyImage="${ENVOY_IMAGE}" \
+    GatewayImageName="${GATEWAY_IMAGE_NAME}" \
+    ColorTellerImageName="${COLOR_TELLER_IMAGE_NAME}"

--- a/walkthroughs/tls-with-acm/infrastructure/ecs-service.yaml
+++ b/walkthroughs/tls-with-acm/infrastructure/ecs-service.yaml
@@ -12,6 +12,18 @@ Parameters:
     Type: String
     Description: DNS namespace used by services e.g. default.svc.cluster.local
 
+  EnvoyImage:
+    Type: String
+    Description: The image to use for the Envoy container
+
+  GatewayImageName:
+    Description: The name for the gateway image
+    Type: String
+
+  ColorTellerImageName:
+    Description: The name for the color teller image
+    Type: String
+
   LoadBalancerPath:
     Type: String
     Default: "*"
@@ -65,7 +77,7 @@ Resources:
             Value: '169.254.170.2,169.254.169.254'
       ContainerDefinitions:
         - Name: 'app'
-          Image: !Sub '${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/colorteller'
+          Image: !Sub '${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/${ColorTellerImageName}'
           Essential: true
           DependsOn:
             - ContainerName: 'envoy'
@@ -86,7 +98,7 @@ Resources:
             - Name: 'COLOR'
               Value: 'white'
         - Name: envoy
-          Image: '111345817488.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-envoy:v1.9.1.0-prod'
+          Image: !Ref EnvoyImage
           Essential: true
           User: '1337'
           Ulimits:
@@ -186,7 +198,7 @@ Resources:
             Value: '169.254.170.2,169.254.169.254'
       ContainerDefinitions:
         - Name: 'app'
-          Image: !Sub '${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/gateway'
+          Image: !Sub '${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/${GatewayImageName}'
           Essential: true
           DependsOn:
             - ContainerName: 'envoy'
@@ -209,7 +221,7 @@ Resources:
             - Name: TCP_ECHO_ENDPOINT
               Value: unused
         - Name: envoy
-          Image: '111345817488.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-envoy:v1.9.1.0-prod'
+          Image: !Ref EnvoyImage
           Essential: true
           User: '1337'
           Ulimits:

--- a/walkthroughs/tls-with-acm/src/colorteller/deploy.sh
+++ b/walkthroughs/tls-with-acm/src/colorteller/deploy.sh
@@ -3,16 +3,18 @@
 
 set -ex
 
-if [ -z $COLOR_TELLER_IMAGE ]; then
-    echo "COLOR_TELLER_IMAGE environment variable is not set"
+if [ -z $COLOR_TELLER_IMAGE_NAME ]; then
+    echo "COLOR_TELLER_IMAGE_NAME environment variable is not set"
     exit 1
 fi
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 
+IMAGE="${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/${COLOR_TELLER_IMAGE_NAME}:latest"
+
 # build
-docker build -t $COLOR_TELLER_IMAGE $DIR
+docker build -t $IMAGE $DIR
 
 # push
-$(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION)
-docker push $COLOR_TELLER_IMAGE
+$(aws ecr get-login --no-include-email)
+docker push $IMAGE

--- a/walkthroughs/tls-with-acm/src/gateway/deploy.sh
+++ b/walkthroughs/tls-with-acm/src/gateway/deploy.sh
@@ -3,20 +3,18 @@
 
 set -ex
 
-if [ -z $COLOR_GATEWAY_IMAGE ]; then
-    echo "COLOR_GATEWAY_IMAGE environment variable is not set"
+if [ -z $GATEWAY_IMAGE_NAME ]; then
+    echo "GATEWAY_IMAGE_NAME environment variable is not set"
     exit 1
 fi
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 
+IMAGE="${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/${GATEWAY_IMAGE_NAME}:latest"
+
 # build
-docker build -t $COLOR_GATEWAY_IMAGE $DIR
+docker build -t $IMAGE $DIR
 
 # push
-if [ -z $AWS_PROFILE  ]; then
-    $(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION)
-else
-    $(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION)
-fi
-docker push $COLOR_GATEWAY_IMAGE
+$(aws ecr get-login --no-include-email)
+docker push $IMAGE


### PR DESCRIPTION
*Description of changes:*

1. Fix a quoting issue in two commands that would fail in bash
2. Remove all hard-coded references to Envoy
3. Add a note about EC2 key pairs
4. Standardize colorteller and gateway image parameters

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
