### PR TITLE
Minor fixes: Adding permissions to access AppMesh, ignoring proxies in Go

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -68,3 +68,7 @@ cd apps/colorapp/src/gateway
 ./deploy.sh
 cd -
 ```
+NOTE: If you run into issues with certificate because GO PROXY server is not reachable, you can turn it off by setting the environment variable `GO_PROXY` as below and then build the docker images
+```
+export GO_PROXY=direct
+```

--- a/examples/apps/colorapp/README.md
+++ b/examples/apps/colorapp/README.md
@@ -289,6 +289,11 @@ The push refers to repository [226767807331.dkr.ecr.us-west-2.amazonaws.com/colo
 latest: digest: sha256:ca16f12268907c32140586e2568e2032f04b95d70b373c00fcee7e776e2d29da size: 528
 $
 ```
+NOTE: If you run into issues with certificate because GO PROXY server is not reachable, you can turn it off by setting the environment variable `GO_PROXY` as below and then build the gateway and colorteller images
+```
+export GO_PROXY=direct
+```
+
 
 #### Deploy gateway and colorteller services
 

--- a/examples/apps/colorapp/src/colorteller/Dockerfile
+++ b/examples/apps/colorapp/src/colorteller/Dockerfile
@@ -1,5 +1,5 @@
 FROM golang:1-stretch as builder
-ARG GO_PROXY=direct
+ARG GO_PROXY=https://proxy.golang.org
 WORKDIR /go/src/github.com/aws/aws-app-mesh-examples/colorapp/teller
 
 # Force the go compiler to use modules.

--- a/examples/apps/colorapp/src/colorteller/Dockerfile
+++ b/examples/apps/colorapp/src/colorteller/Dockerfile
@@ -8,6 +8,8 @@ ENV GO111MODULE=on
 COPY go.mod .
 COPY go.sum .
 
+# Force the go compiler to ignore proxies
+RUN go env -w GOPROXY=direct
 # This ensures `go mod download` happens only when go.mod and go.sum change.
 RUN go mod download
 

--- a/examples/apps/colorapp/src/colorteller/Dockerfile
+++ b/examples/apps/colorapp/src/colorteller/Dockerfile
@@ -1,15 +1,15 @@
 FROM golang:1-stretch as builder
+ARG GO_PROXY=direct
 WORKDIR /go/src/github.com/aws/aws-app-mesh-examples/colorapp/teller
 
 # Force the go compiler to use modules.
 ENV GO111MODULE=on
-
 # go.mod and go.sum go into their own layers.
 COPY go.mod .
 COPY go.sum .
 
-# Force the go compiler to ignore proxies
-RUN go env -w GOPROXY=direct
+# Set the proxies for the go compiler
+RUN go env -w GOPROXY=${GO_PROXY}
 # This ensures `go mod download` happens only when go.mod and go.sum change.
 RUN go mod download
 

--- a/examples/apps/colorapp/src/colorteller/deploy.sh
+++ b/examples/apps/colorapp/src/colorteller/deploy.sh
@@ -15,9 +15,10 @@ fi
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 COLOR_TELLER_IMAGE=${COLOR_TELLER_IMAGE:-"${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/color/teller"}
+GO_PROXY=${GO_PROXY:="https://proxy.golang.org"}
 
 # build
-docker build -t $COLOR_TELLER_IMAGE ${DIR}
+docker build --build-arg GO_PROXY=$GO_PROXY -t $COLOR_TELLER_IMAGE ${DIR}
 
 # push
 $(aws ecr get-login --no-include-email)

--- a/examples/apps/colorapp/src/colorteller/deploy.sh
+++ b/examples/apps/colorapp/src/colorteller/deploy.sh
@@ -15,7 +15,7 @@ fi
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 COLOR_TELLER_IMAGE=${COLOR_TELLER_IMAGE:-"${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/color/teller"}
-GO_PROXY=${GO_PROXY:="https://proxy.golang.org"}
+GO_PROXY=${GO_PROXY:-"https://proxy.golang.org"}
 
 # build
 docker build --build-arg GO_PROXY=$GO_PROXY -t $COLOR_TELLER_IMAGE ${DIR}

--- a/examples/apps/colorapp/src/gateway/Dockerfile
+++ b/examples/apps/colorapp/src/gateway/Dockerfile
@@ -1,4 +1,5 @@
 FROM golang:1-stretch as builder
+ARG GO_PROXY=direct
 WORKDIR /go/src/github.com/aws/aws-app-mesh-examples/colorapp/gateway
 
 # Force the go compiler to use modules.
@@ -8,8 +9,8 @@ ENV GO111MODULE=on
 COPY go.mod .
 COPY go.sum .
 
-# Force the go compiler to ignore proxies
-RUN go env -w GOPROXY=direct
+# Set the proxies for the go compiler
+RUN go env -w GOPROXY=${GO_PROXY}
 # This ensures `go mod download` happens only when go.mod and go.sum change.
 RUN go mod download
 

--- a/examples/apps/colorapp/src/gateway/Dockerfile
+++ b/examples/apps/colorapp/src/gateway/Dockerfile
@@ -8,6 +8,8 @@ ENV GO111MODULE=on
 COPY go.mod .
 COPY go.sum .
 
+# Force the go compiler to ignore proxies
+RUN go env -w GOPROXY=direct
 # This ensures `go mod download` happens only when go.mod and go.sum change.
 RUN go mod download
 

--- a/examples/apps/colorapp/src/gateway/Dockerfile
+++ b/examples/apps/colorapp/src/gateway/Dockerfile
@@ -1,5 +1,5 @@
 FROM golang:1-stretch as builder
-ARG GO_PROXY=direct
+ARG GO_PROXY=https://proxy.golang.org
 WORKDIR /go/src/github.com/aws/aws-app-mesh-examples/colorapp/gateway
 
 # Force the go compiler to use modules.

--- a/examples/apps/colorapp/src/gateway/deploy.sh
+++ b/examples/apps/colorapp/src/gateway/deploy.sh
@@ -15,9 +15,10 @@ fi
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 COLOR_GATEWAY_IMAGE=${COLOR_GATEWAY_IMAGE:-"${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/color/gateway"}
+GO_PROXY=${GO_PROXY:="https://proxy.golang.org"}
 
 # build
-docker build -t $COLOR_GATEWAY_IMAGE ${DIR}
+docker build --build-arg GO_PROXY=$GO_PROXY -t $COLOR_GATEWAY_IMAGE ${DIR}
 
 # push
 $(aws ecr get-login --no-include-email)

--- a/examples/apps/colorapp/src/gateway/deploy.sh
+++ b/examples/apps/colorapp/src/gateway/deploy.sh
@@ -15,7 +15,7 @@ fi
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 COLOR_GATEWAY_IMAGE=${COLOR_GATEWAY_IMAGE:-"${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/color/gateway"}
-GO_PROXY=${GO_PROXY:="https://proxy.golang.org"}
+GO_PROXY=${GO_PROXY:-"https://proxy.golang.org"}
 
 # build
 docker build --build-arg GO_PROXY=$GO_PROXY -t $COLOR_GATEWAY_IMAGE ${DIR}

--- a/examples/infrastructure/ecs-cluster.yaml
+++ b/examples/infrastructure/ecs-cluster.yaml
@@ -335,6 +335,7 @@ Resources:
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/CloudWatchFullAccess
         - arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess
+        - arn:aws:iam::aws:policy/AWSAppMeshEnvoyAccess
 
   TaskExecutionIamRole:
     Type: AWS::IAM::Role

--- a/walkthroughs/http-headers-and-priority/header.yaml
+++ b/walkthroughs/http-headers-and-priority/header.yaml
@@ -41,6 +41,7 @@ Resources:
         }
       ManagedPolicyArns:
       - arn:aws:iam::aws:policy/CloudWatchFullAccess
+      - arn:aws:iam::aws:policy/AWSAppMeshEnvoyAccess
 
   TaskExecutionIamRole:
     Type: AWS::IAM::Role

--- a/walkthroughs/http-headers-and-priority/header.yaml
+++ b/walkthroughs/http-headers-and-priority/header.yaml
@@ -41,6 +41,7 @@ Resources:
         }
       ManagedPolicyArns:
       - arn:aws:iam::aws:policy/CloudWatchFullAccess
+      - arn:aws:iam::aws:policy/AWSAppMeshPreviewEnvoyAccess
       - arn:aws:iam::aws:policy/AWSAppMeshEnvoyAccess
 
   TaskExecutionIamRole:

--- a/walkthroughs/http-retry-policy/retrypolicy.yaml
+++ b/walkthroughs/http-retry-policy/retrypolicy.yaml
@@ -41,6 +41,7 @@ Resources:
         }
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/CloudWatchFullAccess
+        - arn:aws:iam::aws:policy/AWSAppMeshPreviewEnvoyAccess
         - arn:aws:iam::aws:policy/AWSAppMeshEnvoyAccess
 
   TaskExecutionIamRole:

--- a/walkthroughs/http-retry-policy/retrypolicy.yaml
+++ b/walkthroughs/http-retry-policy/retrypolicy.yaml
@@ -41,6 +41,7 @@ Resources:
         }
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/CloudWatchFullAccess
+        - arn:aws:iam::aws:policy/AWSAppMeshEnvoyAccess
 
   TaskExecutionIamRole:
     Type: AWS::IAM::Role

--- a/walkthroughs/tls-with-acm/src/colorteller/Dockerfile
+++ b/walkthroughs/tls-with-acm/src/colorteller/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.10 AS builder
+FROM golang:1-stretch AS builder
 
 # Download and install the latest release of dep
 ADD https://github.com/golang/dep/releases/download/v0.4.1/dep-linux-amd64 /usr/bin/dep

--- a/walkthroughs/tls-with-acm/src/gateway/Dockerfile
+++ b/walkthroughs/tls-with-acm/src/gateway/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.10 AS builder
+FROM golang:1-stretch AS builder
 
 # Download and install the latest release of dep
 ADD https://github.com/golang/dep/releases/download/v0.4.1/dep-linux-amd64 /usr/bin/dep


### PR DESCRIPTION
*Minor fixes when running colorapp in ECS:*

*Description of changes:*
* Adding permissions to access AppMesh 
* Ignoring proxies in Go


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
