### PR TITLE
clean up ecr images in a few walkthroughs

### DIFF
--- a/walkthroughs/howto-alb/deploy.sh
+++ b/walkthroughs/howto-alb/deploy.sh
@@ -72,7 +72,7 @@ print_endpoint() {
     echo "${prefix}/color"
 }
 
-deploy_stacks() {
+deploy_resources() {
 
     if [ -z $SKIP_IMAGES ]; then
         echo "deploy images..."
@@ -89,18 +89,32 @@ deploy_stacks() {
     print_endpoint
 }
 
-delete_stacks() {
+delete_images() {
+    for app in colorapp feapp; do
+        echo "deleting repository..."
+        aws ecr delete-repository \
+           --repository-name $PROJECT_NAME/$app \
+           --force
+    done
+}
+
+delete_resources() {
     echo "delete app..."
     delete_cfn_stack "${PROJECT_NAME}-app"
 
     echo "delete infra..."
     delete_cfn_stack "${PROJECT_NAME}-infra"
+
+    echo "delete images..."
+    delete_images
+
+    echo "all resources from this tutorial have been removed"
 }
 
 action=${1:-"deploy"}
 if [ "$action" == "delete" ]; then
-    delete_stacks
+    delete_resources
     exit 0
 fi
 
-deploy_stacks
+deploy_resources

--- a/walkthroughs/howto-grpc/deploy.sh
+++ b/walkthroughs/howto-grpc/deploy.sh
@@ -119,10 +119,29 @@ delete_mesh() {
     aws appmesh-preview delete-mesh --mesh-name $mesh_name
 }
 
+delete_images() {
+    for app in color_client color_server; do
+        echo "deleting repository..."
+        aws ecr delete-repository \
+           --repository-name $PROJECT_NAME/$app \
+           --force
+    done
+}
+
 delete_stacks() {
+    echo "delete app..."
     delete_cfn_stack "${PROJECT_NAME}-app"
+
+    echo "delete-infra..."
     delete_cfn_stack "${PROJECT_NAME}-infra"
+
+    echo "delete mesh..."
     delete_mesh
+
+    echo "delete images..."
+    delete_images
+
+    echo "all resources from this tutorial have been removed"
 }
 
 action=${1:-"deploy"}

--- a/walkthroughs/howto-grpc/deploy.sh
+++ b/walkthroughs/howto-grpc/deploy.sh
@@ -121,7 +121,7 @@ delete_mesh() {
 
 delete_images() {
     for app in color_client color_server; do
-        echo "deleting repository..."
+        echo "deleting repository \"${app}\"..."
         aws ecr delete-repository \
            --repository-name $PROJECT_NAME/$app \
            --force
@@ -129,16 +129,12 @@ delete_images() {
 }
 
 delete_stacks() {
-    echo "delete app..."
     delete_cfn_stack "${PROJECT_NAME}-app"
 
-    echo "delete-infra..."
     delete_cfn_stack "${PROJECT_NAME}-infra"
 
-    echo "delete mesh..."
     delete_mesh
 
-    echo "delete images..."
     delete_images
 
     echo "all resources from this tutorial have been removed"

--- a/walkthroughs/howto-http-headers/README.md
+++ b/walkthroughs/howto-http-headers/README.md
@@ -8,22 +8,22 @@ This mesh has the following resources:
 * A Virtual Router named `color-router` which serves as the provider for the virtual service above.
 * 8 Virtual Nodes:
   1. `front-node`: Sends egress traffic to the `color.header-mesh.local` Virtual Service. It discovers instances via Cloud Map in the `front` service under the `howto-http-headers.local` namespace.
-  2. `purple-node`: A Cloud Map Node for `color.header-mesh.local` that discovers instances with the attribute `ECS_TASK_DEFINITION_FAMILY` set to `purple`.
-  3. `yellow-node`: A Cloud Map Node for `color.header-mesh.local` that discovers instances with the attribute `ECS_TASK_DEFINITION_FAMILY` set to `yellow`.
-  4. `blue-node`: A Cloud Map Node for `color.header-mesh.local` that discovers instances with the attribute `ECS_TASK_DEFINITION_FAMILY` set to `blue`.
-  5. `green-node`: A Cloud Map Node for `color.header-mesh.local` that discovers instances with the attribute `ECS_TASK_DEFINITION_FAMILY` set to `green`.
-  6. `red-node`: A Cloud Map Node for `color.header-mesh.local` that discovers instances with the attribute `ECS_TASK_DEFINITION_FAMILY` set to `red`.
-  7. `white-node`: A Cloud Map Node for `color.header-mesh.local` that discovers instances with the attribute `ECS_TASK_DEFINITION_FAMILY` set to `white`.
-  8. `black-node`: A Cloud Map Node for `color.header-mesh.local` that discovers instances with the attribute `ECS_TASK_DEFINITION_FAMILY` set to `black`.
+  1. `purple-node`: A Cloud Map Node for `color.header-mesh.local` that discovers instances with the attribute `ECS_TASK_DEFINITION_FAMILY` set to `purple`.
+  1. `yellow-node`: A Cloud Map Node for `color.header-mesh.local` that discovers instances with the attribute `ECS_TASK_DEFINITION_FAMILY` set to `yellow`.
+  1. `blue-node`: A Cloud Map Node for `color.header-mesh.local` that discovers instances with the attribute `ECS_TASK_DEFINITION_FAMILY` set to `blue`.
+  1. `green-node`: A Cloud Map Node for `color.header-mesh.local` that discovers instances with the attribute `ECS_TASK_DEFINITION_FAMILY` set to `green`.
+  1. `red-node`: A Cloud Map Node for `color.header-mesh.local` that discovers instances with the attribute `ECS_TASK_DEFINITION_FAMILY` set to `red`.
+  1. `white-node`: A Cloud Map Node for `color.header-mesh.local` that discovers instances with the attribute `ECS_TASK_DEFINITION_FAMILY` set to `white`.
+  1. `black-node`: A Cloud Map Node for `color.header-mesh.local` that discovers instances with the attribute `ECS_TASK_DEFINITION_FAMILY` set to `black`.
   
 * 7 Routes: 
   1. `color-route-purple`: A route with a header match rule to match weather the header name `color_header` _does not_ exist.
-  2. `color-route-yellow`: A route with a header match rule to match weather the header name `color_header` _does_ exist.
-  3. `color-route-blue`: A route with a header match rule to match weather the header `color_header` has a value within the range `[100, 150)` (excludes 150).
-  4. `color-route-green`: A route with a header match rule to match weather the header name `color_header` has a value that matches the regex `redor.*`.
-  5. `color-route-red`: A route with a header match rule to match weather the header name `color_header` has a value that matches the prefix `redorgreen`.
-  6. `color-route-white`: A route with a header match rule to match weather the pseudo header name `:method` has a value that matches `GET`.
-  7. `color-route-black`: A route with a header match rule to match weather the pseudo header name `:scheme` has a value that matches the prefix `https`.
+  1. `color-route-yellow`: A route with a header match rule to match weather the header name `color_header` _does_ exist.
+  1. `color-route-blue`: A route with a header match rule to match weather the header `color_header` has a value within the range `[100, 150)` (excludes 150).
+  1. `color-route-green`: A route with a header match rule to match weather the header name `color_header` has a value that matches the regex `redor.*`.
+  1. `color-route-red`: A route with a header match rule to match weather the header name `color_header` has a value that matches the prefix `redorgreen`.
+  1. `color-route-white`: A route with a header match rule to match weather the pseudo header name `:method` has a value that matches `GET`.
+  1. `color-route-black`: A route with a header match rule to match weather the pseudo header name `:scheme` has a value that matches the prefix `https`.
 
 ## Setup
 
@@ -31,22 +31,22 @@ This mesh has the following resources:
     ```
     export AWS_ACCOUNT_ID=<your_account_id>
     ```
-2. Your region:
+1. Your region:
     ```
     export AWS_DEFAULT_REGION=<i.e. us-west-2>
     ```
     
-3. The latest envoy image, see https://docs.aws.amazon.com/app-mesh/latest/userguide/envoy.html
+1. The latest envoy image, see https://docs.aws.amazon.com/app-mesh/latest/userguide/envoy.html
    ```
    export ENVOY_IMAGE=<from_appmesh_user_guide_above>
    ```
     
-4. Deploy the resources (this will take about 5-10 minutes to complete):
+1. Deploy the resources (this will take about 5-10 minutes to complete):
     ```
     ./deploy.sh
     ```
    
-5. Once the script has executed there will be a public endpoint, save this for later.
+1. Once the script has executed there will be a public endpoint, save this for later.
 
 ## Update Route
 
@@ -56,28 +56,28 @@ For instance, to describe the blue route using the CLI:
   aws appmesh describe-route --mesh-name howto-http-headers --virtual-router-name color-router --route-name color-route-blue
   ```
 
-2. For example routing a request with the _color_header_ header value set to _redorgreencolor_ will route to the green service (matching on regex _redor.*_) even though it also
+1. For example routing a request with the _color_header_ header value set to _redorgreencolor_ will route to the green service (matching on regex _redor.*_) even though it also
 applies to the red service (matching on the prefix _redorgreen_). This is because the route priority attribute for the green route has higher priority than the red route. 
 To see this run the following command where endpoint refers to the output from the deploy script in the previous section:    
   ```
   curl --header "color_header: redorgreencolor" <endpoint>
   ```
 
-3. Lets update the red route to have a higher priority than the green route. Run the following command to update the priority on the red route
+1. Lets update the red route to have a higher priority than the green route. Run the following command to update the priority on the red route
 then rerun the curl command above. You should be routing to red now.  
   ```
   aws appmesh update-route --mesh-name howto-http-headers --cli-input-json file://color-route.json
   ```
   
-4. Feel free to update various routes in the json file above by changing the route name. Reference these docs to test the various
+1. Feel free to update various routes in the json file above by changing the route name. Reference these docs to test the various
 [header routing rules](https://docs.aws.amazon.com/app-mesh/latest/APIReference/API_HttpRouteMatch.html) and [priority](https://docs.aws.amazon.com/app-mesh/latest/APIReference/API_RouteSpec.html). 
 
 ## Clean up 
 
 Run the following command to remove all resources created from this demo: 
-```
-./deploy.sh delete
-```
+    ```
+    ./deploy.sh delete
+    ```
 
 Alternatively, to manually delete resources delete the two stacks this walkthrough created (named _howto-http-headers-app_ and _howto-http-headers-infra_). 
 Also go to ECR in the console and remove all images associated to the two repositories created (_named howto-http-headers/colorapp_ and _howto-http-headers-feapp_) 

--- a/walkthroughs/howto-http-headers/deploy.sh
+++ b/walkthroughs/howto-http-headers/deploy.sh
@@ -88,7 +88,7 @@ print_endpoint() {
     echo "${prefix}"
 }
 
-deploy_stacks() {
+deploy_resources() {
 
     echo "deploy images..."
     deploy_images
@@ -103,7 +103,7 @@ deploy_stacks() {
     print_endpoint
 }
 
-delete_stacks() {
+delete_resources() {
     echo "delete app..."
     delete_cfn_stack "${PROJECT_NAME}-app"
 
@@ -112,12 +112,14 @@ delete_stacks() {
 
     echo "delete images..."
     delete_images
+
+    echo "all resources from this tutorial have been removed"
 }
 
 action=${1:-"deploy"}
 if [ "$action" == "delete" ]; then
-    delete_stacks
+    delete_resources
     exit 0
 fi
 
-deploy_stacks
+deploy_resources

--- a/walkthroughs/howto-http2/deploy.sh
+++ b/walkthroughs/howto-http2/deploy.sh
@@ -123,10 +123,30 @@ delete_mesh() {
     aws appmesh-preview delete-mesh --mesh-name $mesh_name
 }
 
+delete_images() {
+    for app in color_client color_server; do
+        echo "deleting repository..."
+        aws ecr delete-repository \
+           --repository-name $PROJECT_NAME/$app \
+           --force
+    done
+}
+
 delete_stacks() {
+
+    echo "delete app..."
     delete_cfn_stack "${PROJECT_NAME}-app"
+
+    echo "delete infra"
     delete_cfn_stack "${PROJECT_NAME}-infra"
+
+    echo "delete mesh..."
     delete_mesh
+
+    echo "delete images..."
+    delete_images
+
+    echo "all resources from this tutorial have been removed"
 }
 
 action=${1:-"deploy"}

--- a/walkthroughs/howto-http2/deploy.sh
+++ b/walkthroughs/howto-http2/deploy.sh
@@ -125,7 +125,7 @@ delete_mesh() {
 
 delete_images() {
     for app in color_client color_server; do
-        echo "deleting repository..."
+        echo "deleting repository \"${app}\"..."
         aws ecr delete-repository \
            --repository-name $PROJECT_NAME/$app \
            --force
@@ -133,17 +133,12 @@ delete_images() {
 }
 
 delete_stacks() {
-
-    echo "delete app..."
     delete_cfn_stack "${PROJECT_NAME}-app"
 
-    echo "delete infra"
     delete_cfn_stack "${PROJECT_NAME}-infra"
 
-    echo "delete mesh..."
     delete_mesh
 
-    echo "delete images..."
     delete_images
 
     echo "all resources from this tutorial have been removed"


### PR DESCRIPTION
*Issue #, if available:*

Adding ecr image deletion as part of teardown for alb, http2, and grpc. Some clean up in http header walkthrough


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
