### PR TITLE
Pin gunicorn version to 19.9.0 in flask-based examples

### DIFF
--- a/walkthroughs/howto-alb/colorapp/requirements.txt
+++ b/walkthroughs/howto-alb/colorapp/requirements.txt
@@ -1,3 +1,3 @@
 flask
 aws-xray-sdk
-gunicorn
+gunicorn==19.9.0

--- a/walkthroughs/howto-alb/feapp/requirements.txt
+++ b/walkthroughs/howto-alb/feapp/requirements.txt
@@ -1,4 +1,4 @@
 flask
 requests
 aws-xray-sdk
-gunicorn
+gunicorn==19.9.0

--- a/walkthroughs/howto-k8s-cloudmap/colorapp/requirements.txt
+++ b/walkthroughs/howto-k8s-cloudmap/colorapp/requirements.txt
@@ -1,3 +1,3 @@
 flask
 aws-xray-sdk
-gunicorn
+gunicorn==19.9.0

--- a/walkthroughs/howto-k8s-cloudmap/feapp/requirements.txt
+++ b/walkthroughs/howto-k8s-cloudmap/feapp/requirements.txt
@@ -1,4 +1,4 @@
 flask
 requests
 aws-xray-sdk
-gunicorn
+gunicorn==19.9.0

--- a/walkthroughs/howto-k8s-cross-cluster/colorapp/requirements.txt
+++ b/walkthroughs/howto-k8s-cross-cluster/colorapp/requirements.txt
@@ -1,3 +1,3 @@
 flask
 aws-xray-sdk
-gunicorn
+gunicorn==19.9.0

--- a/walkthroughs/howto-k8s-cross-cluster/feapp/requirements.txt
+++ b/walkthroughs/howto-k8s-cross-cluster/feapp/requirements.txt
@@ -1,4 +1,4 @@
 flask
 requests
 aws-xray-sdk
-gunicorn
+gunicorn==19.9.0


### PR DESCRIPTION
Fixes: #231 

gunicorn 20.0.0 does not work on the python:alpine image


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
