### PR TITLE
use docker images as used elsewhere in the documentation

### DIFF
--- a/examples/apps/colorapp/src/colorteller/deploy.sh
+++ b/examples/apps/colorapp/src/colorteller/deploy.sh
@@ -14,7 +14,7 @@ if [ -z $AWS_DEFAULT_REGION ]; then
 fi
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
-COLOR_TELLER_IMAGE=${COLOR_TELLER_IMAGE:-"${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/color/teller"}
+COLOR_TELLER_IMAGE=${COLOR_TELLER_IMAGE:-"${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/colorteller"}
 GO_PROXY=${GO_PROXY:-"https://proxy.golang.org"}
 
 # build

--- a/examples/apps/colorapp/src/gateway/deploy.sh
+++ b/examples/apps/colorapp/src/gateway/deploy.sh
@@ -14,7 +14,7 @@ if [ -z $AWS_DEFAULT_REGION ]; then
 fi
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
-COLOR_GATEWAY_IMAGE=${COLOR_GATEWAY_IMAGE:-"${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/color/gateway"}
+COLOR_GATEWAY_IMAGE=${COLOR_GATEWAY_IMAGE:-"${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/gateway"}
 GO_PROXY=${GO_PROXY:-"https://proxy.golang.org"}
 
 # build


### PR DESCRIPTION
On this page https://github.com/aws/aws-app-mesh-examples/tree/master/examples/apps/colorapp - the image is being referred to as -


```
export COLOR_GATEWAY_IMAGE=226767807331.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/gateway
export COLOR_TELLER_IMAGE=226767807331.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/colorteller:latest
```

But the deploy script currently tries to push to `.amazonaws.com/color/teller"`

It probably needs to be `.amazonaws.com/colorteller"` and `.amazonaws.com/gateway"`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
