### PR TITLE
Set appmesh-inject to use color-mesh not global

### DIFF
--- a/walkthroughs/eks/base.md
+++ b/walkthroughs/eks/base.md
@@ -76,7 +76,7 @@ helm repo add eks https://aws.github.io/eks-charts
 kubectl create ns appmesh-system
 kubectl apply -f https://raw.githubusercontent.com/aws/eks-charts/master/stable/appmesh-controller/crds/crds.yaml
 helm upgrade -i appmesh-controller eks/appmesh-controller --namespace appmesh-system
-helm upgrade -i appmesh-inject eks/appmesh-inject --namespace appmesh-system --set mesh.create=true --set mesh.name=global
+helm upgrade -i appmesh-inject eks/appmesh-inject --namespace appmesh-system --set mesh.create=true --set mesh.name=color-mesh
 
 Opitionally add tracing
 helm upgrade -i appmesh-inject eks/appmesh-inject --namespace appmesh-system --set tracing.enabled=true --set tracing.provider=x-ray


### PR DESCRIPTION
Otherwise I get

```
root@curler-696578658b-t9r2q:/# curl colorgateway:9080/color
curl: (7) Failed to connect to colorgateway port 9080: Connection refused
```

Which makes sense, because the injector sets the pod environments to look at `global` instead of `color-mesh`:

```
aws-app-mesh-controller-for-k8s/examples [master●] » kubectl get po colorgateway-7fc6cdb87c-krdsg -o yaml
apiVersion: v1
kind: Pod
metadata:
...
spec:
  containers:
  - env:
    - name: APPMESH_VIRTUAL_NODE_NAME
      value: mesh/global/virtualNode/colorgateway-appmesh-demo
```

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
