### PR TITLE
[BUG] Fix invalid value for `MinimumHealthyPercent`

### DIFF
--- a/walkthroughs/howto-ecs-basics/deploy/1-servicediscovery.yaml
+++ b/walkthroughs/howto-ecs-basics/deploy/1-servicediscovery.yaml
@@ -437,7 +437,7 @@ Resources:
       Cluster: !Ref ECSCluster
       DeploymentConfiguration:
         MaximumPercent: 200
-        MinimumHealthyPercent: 100`
+        MinimumHealthyPercent: 100
       DesiredCount: 3
       LaunchType: 'FARGATE'
       TaskDefinition: !Ref FrontTaskDef


### PR DESCRIPTION
*Description of changes:*

When running `deploy.sh deploy 1-servicediscovery`, Cloudformation fails to update the stack `appmesh-howto-ecs-basics` as an invalid value is set to MinimumHealthyPercent. This pull request fixes this issue.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
