### PR TITLE
Add client policy to ACM TLS example

### DIFF
--- a/walkthroughs/tls-with-acm/infrastructure/ecs-cluster.yaml
+++ b/walkthroughs/tls-with-acm/infrastructure/ecs-cluster.yaml
@@ -81,6 +81,15 @@ Resources:
               "Resource": ["*"]
             }]
           }
+      - PolicyName: ACMCertificateAuthorityAccess
+        PolicyDocument: |
+          {
+            "Statement": [{
+              "Effect": "Allow",
+              "Action": ["acm-pca:GetCertificateAuthorityCertificate"],
+              "Resource": ["*"]
+            }]
+          }
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/CloudWatchFullAccess
         - arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess

--- a/walkthroughs/tls-with-acm/mesh/colorgateway-vn.json
+++ b/walkthroughs/tls-with-acm/mesh/colorgateway-vn.json
@@ -14,7 +14,24 @@
             }
         },
         "backends": [
-            {"virtualService": {"virtualServiceName": $COLOR_TELLER_VS }}
+            {
+                "virtualService": {
+                    "virtualServiceName": $COLOR_TELLER_VS,
+                    "clientPolicy": {
+                        "tls": {
+                            "validation": {
+                                "trust": {
+                                    "acm": {
+                                        "certificateAuthorityArns": [
+                                            $ROOT_CA_ARN
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         ]
     }
 }

--- a/walkthroughs/tls-with-acm/mesh/mesh.sh
+++ b/walkthroughs/tls-with-acm/mesh/mesh.sh
@@ -50,6 +50,7 @@ create_vnode() {
     vnode_name=$2
     dns_hostname="$3.${SERVICES_DOMAIN}"
     cli_input=$( jq -n \
+        --arg ROOT_CA_ARN "${ROOT_CA_ARN}" \
         --arg CERTIFICATE_ARN "${CERTIFICATE_ARN}" \
         --arg DNS_HOSTNAME "$3.${SERVICES_DOMAIN}" \
         --arg COLOR_TELLER_VS "colorteller.${SERVICES_DOMAIN}" \


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws/aws-app-mesh-roadmap/issues/39
https://github.com/aws/aws-app-mesh-roadmap/issues/38

*Description of changes:*

Add a client policy on the gateway virtual node to enforce and validate the TLS session with the color teller virtual node.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
