### PR TITLE
Update to the correct virtual service name

### DIFF
--- a/walkthroughs/eks/base.md
+++ b/walkthroughs/eks/base.md
@@ -206,15 +206,15 @@ kubectl -n appmesh-demo \
           --image=tutum/curl /bin/bash
 # If you don't see a command prompt, try pressing enter.
 # root@curler-5b467f98bb-lmwm9:/#
-curl colorgateway:9080/color
+curl colorgateway.appmesh-demo:9080/color
 # {"color":"black", "stats": {"black":1}}
 
 # root@curler-5b467f98bb-lmwm9:/#
-curl colorgateway:9080/color
+curl colorgateway.appmesh-demo:9080/color
 # {"color":"white", "stats": {"black":0.67,"white":0.33}}
 ...
 # root@curler-5b467f98bb-lmwm9:/#
-curl colorgateway:9080/color
+curl colorgateway.appmesh-demo:9080/color
 # {"color":"blue", "stats": {"black":0.5,"blue":0.2,"white":0.3}}
 ```
 


### PR DESCRIPTION
*Issue #, if available:*
After installing the colorapp, there is a section with an example of how to test the colorapp. But it fails.

It uses this command: `curl colorgateway:9080/color`. But it lacks the full virtual service name: `colorgateway.appmesh-demo`

*Description of changes:*
Updated the full virtual service name `colorgateway.appmesh-demo`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
