### PR TITLE
Update howto-ecs-basics to supply a GOPROXY override to the container images

### DIFF
--- a/walkthroughs/howto-ecs-basics/deploy.sh
+++ b/walkthroughs/howto-ecs-basics/deploy.sh
@@ -24,6 +24,7 @@ ECR_IMAGE_PREFIX=${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/$
 CW_AGENT_IMAGE="${ECR_IMAGE_PREFIX}/cwagent:$(git log -1 --format=%h src/cwagent)"
 COLOR_APP_IMAGE="${ECR_IMAGE_PREFIX}/colorapp:$(git log -1 --format=%h src/colorapp)"
 FRONT_APP_IMAGE="${ECR_IMAGE_PREFIX}/feapp:$(git log -1 --format=%h src/feapp)"
+GO_PROXY=${GO_PROXY:-"https://proxy.golang.org"}
 
 # deploy_images builds and pushes docker images for colorapp and feapp to ECR
 deploy_images() {
@@ -32,9 +33,9 @@ deploy_images() {
     done
 
     $(aws ecr get-login --no-include-email)
-    docker build -t ${CW_AGENT_IMAGE} ${DIR}/src/cwagent && docker push ${CW_AGENT_IMAGE}
-    docker build -t ${COLOR_APP_IMAGE} ${DIR}/src/colorapp && docker push ${COLOR_APP_IMAGE}
-    docker build -t ${FRONT_APP_IMAGE} ${DIR}/src/feapp && docker push ${FRONT_APP_IMAGE}
+    docker build -t ${CW_AGENT_IMAGE} --build-arg GO_PROXY=${GO_PROXY} ${DIR}/src/cwagent && docker push ${CW_AGENT_IMAGE}
+    docker build -t ${COLOR_APP_IMAGE} --build-arg GO_PROXY=${GO_PROXY} ${DIR}/src/colorapp && docker push ${COLOR_APP_IMAGE}
+    docker build -t ${FRONT_APP_IMAGE} --build-arg GO_PROXY=${GO_PROXY} ${DIR}/src/feapp && docker push ${FRONT_APP_IMAGE}
 }
 
 # deploy deploys infra, colorapp and feapp.

--- a/walkthroughs/howto-ecs-basics/deploy.sh
+++ b/walkthroughs/howto-ecs-basics/deploy.sh
@@ -33,7 +33,7 @@ deploy_images() {
     done
 
     $(aws ecr get-login --no-include-email)
-    docker build -t ${CW_AGENT_IMAGE} --build-arg GO_PROXY=${GO_PROXY} ${DIR}/src/cwagent && docker push ${CW_AGENT_IMAGE}
+    docker build -t ${CW_AGENT_IMAGE} ${DIR}/src/cwagent && docker push ${CW_AGENT_IMAGE}
     docker build -t ${COLOR_APP_IMAGE} --build-arg GO_PROXY=${GO_PROXY} ${DIR}/src/colorapp && docker push ${COLOR_APP_IMAGE}
     docker build -t ${FRONT_APP_IMAGE} --build-arg GO_PROXY=${GO_PROXY} ${DIR}/src/feapp && docker push ${FRONT_APP_IMAGE}
 }


### PR DESCRIPTION
*Description of changes:*

This just makes it easier to override the GOPROXY when running this in a restricted network environment.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
