### PR TITLE
Avoid using deprecated command get-login

### DIFF
--- a/examples/apps/colorapp/src/colorteller/deploy.sh
+++ b/examples/apps/colorapp/src/colorteller/deploy.sh
@@ -14,12 +14,13 @@ if [ -z $AWS_DEFAULT_REGION ]; then
 fi
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
-COLOR_TELLER_IMAGE=${COLOR_TELLER_IMAGE:-"${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/colorteller"}
+ECR_REGISTRY=${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com
+COLOR_TELLER_IMAGE=${COLOR_TELLER_IMAGE:-"${ECR_REGISTRY}/colorteller"}
 GO_PROXY=${GO_PROXY:-"https://proxy.golang.org"}
 
 # build
 docker build --build-arg GO_PROXY=$GO_PROXY -t $COLOR_TELLER_IMAGE ${DIR}
 
 # push
-$(aws ecr get-login --no-include-email)
+aws ecr get-login-password | docker login --username AWS --password-stdin ${ECR_REGISTRY}
 docker push $COLOR_TELLER_IMAGE

--- a/examples/apps/colorapp/src/gateway/deploy.sh
+++ b/examples/apps/colorapp/src/gateway/deploy.sh
@@ -14,12 +14,13 @@ if [ -z $AWS_DEFAULT_REGION ]; then
 fi
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
-COLOR_GATEWAY_IMAGE=${COLOR_GATEWAY_IMAGE:-"${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/gateway"}
+ECR_REGISTRY=${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com
+COLOR_GATEWAY_IMAGE=${COLOR_GATEWAY_IMAGE:-"${ECR_REGISTRY}/gateway"}
 GO_PROXY=${GO_PROXY:-"https://proxy.golang.org"}
 
 # build
 docker build --build-arg GO_PROXY=$GO_PROXY -t $COLOR_GATEWAY_IMAGE ${DIR}
 
 # push
-$(aws ecr get-login --no-include-email)
+aws ecr get-login-password | docker login --username AWS --password-stdin ${ECR_REGISTRY}
 docker push $COLOR_GATEWAY_IMAGE

--- a/walkthroughs/howto-alb/deploy.sh
+++ b/walkthroughs/howto-alb/deploy.sh
@@ -19,13 +19,14 @@ fi
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
 PROJECT_NAME="howto-alb"
-ECR_IMAGE_PREFIX=${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/${PROJECT_NAME}
+ECR_REGISTRY=${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com
+ECR_IMAGE_PREFIX=${ECR_REGISTRY}/${PROJECT_NAME}
 
 deploy_images() {
     for app in colorapp feapp; do
         aws ecr describe-repositories --repository-name $PROJECT_NAME/$app >/dev/null 2>&1 || aws ecr create-repository --repository-name $PROJECT_NAME/$app
         docker build -t ${ECR_IMAGE_PREFIX}/${app} ${DIR}/${app}
-        $(aws ecr get-login --no-include-email)
+        aws ecr get-login-password | docker login --username AWS --password-stdin ${ECR_REGISTRY}
         docker push ${ECR_IMAGE_PREFIX}/${app}
     done
 }

--- a/walkthroughs/howto-cross-account/primary-account/deploy.sh
+++ b/walkthroughs/howto-cross-account/primary-account/deploy.sh
@@ -11,13 +11,14 @@ if [ -z $AWS_PROFILE ]; then
 fi
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
-ECR_IMAGE_PREFIX=${AWS_PRIMARY_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/${PROJECT_NAME}
+ECR_REGISTRY=${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com
+ECR_IMAGE_PREFIX=${ECR_REGISTRY}/${PROJECT_NAME}
 
 deploy_image() {
     echo "Deploying Gateway image to ECR..."
     aws ecr describe-repositories --repository-name ${PROJECT_NAME}/gateway >/dev/null 2>&1 || aws ecr create-repository --repository-name ${PROJECT_NAME}/gateway
     docker build -t ${ECR_IMAGE_PREFIX}/gateway ${DIR}/gateway --build-arg BACKEND_SERVICE=backend.${PROJECT_NAME}.local
-    $(aws --profile ${AWS_PROFILE} ecr get-login --no-include-email)
+    aws ecr get-login-password | docker login --username AWS --password-stdin ${ECR_REGISTRY}
     docker push ${ECR_IMAGE_PREFIX}/gateway
 }
 

--- a/walkthroughs/howto-ecs-basics/deploy.sh
+++ b/walkthroughs/howto-ecs-basics/deploy.sh
@@ -20,7 +20,8 @@ fi
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
 PROJECT_NAME="$(basename ${DIR})"
 STACK_NAME="appmesh-${PROJECT_NAME}"
-ECR_IMAGE_PREFIX=${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/${PROJECT_NAME}
+ECR_REGISTRY=${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com
+ECR_IMAGE_PREFIX=${ECR_REGISTRY}/${PROJECT_NAME}
 CW_AGENT_IMAGE="${ECR_IMAGE_PREFIX}/cwagent:$(git log -1 --format=%h src/cwagent)"
 COLOR_APP_IMAGE="${ECR_IMAGE_PREFIX}/colorapp:$(git log -1 --format=%h src/colorapp)"
 FRONT_APP_IMAGE="${ECR_IMAGE_PREFIX}/feapp:$(git log -1 --format=%h src/feapp)"
@@ -32,7 +33,7 @@ deploy_images() {
         aws ecr describe-repositories --repository-name ${PROJECT_NAME}/${f} >/dev/null 2>&1 || aws ecr create-repository --repository-name ${PROJECT_NAME}/${f}
     done
 
-    $(aws ecr get-login --no-include-email)
+    aws ecr get-login-password | docker login --username AWS --password-stdin ${ECR_REGISTRY}
     docker build -t ${CW_AGENT_IMAGE} ${DIR}/src/cwagent && docker push ${CW_AGENT_IMAGE}
     docker build -t ${COLOR_APP_IMAGE} --build-arg GO_PROXY=${GO_PROXY} ${DIR}/src/colorapp && docker push ${COLOR_APP_IMAGE}
     docker build -t ${FRONT_APP_IMAGE} --build-arg GO_PROXY=${GO_PROXY} ${DIR}/src/feapp && docker push ${FRONT_APP_IMAGE}

--- a/walkthroughs/howto-grpc/deploy.sh
+++ b/walkthroughs/howto-grpc/deploy.sh
@@ -28,14 +28,15 @@ if [ -z $KEY_PAIR ]; then
 fi
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
-ECR_IMAGE_PREFIX=${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/${PROJECT_NAME}
+ECR_REGISTRY=${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com
+ECR_IMAGE_PREFIX=${ECR_REGISTRY}/${PROJECT_NAME}
 
 deploy_images() {
     echo "Deploying Color Client and Color Server images to ECR..."
     for app in color_client color_server; do
         aws ecr describe-repositories --repository-name ${PROJECT_NAME}/${app} >/dev/null 2>&1 || aws ecr create-repository --repository-name ${PROJECT_NAME}/${app}
         docker build -t ${ECR_IMAGE_PREFIX}/${app} ${DIR}/${app} --build-arg GO_PROXY=${GO_PROXY:-"https://proxy.golang.org"}
-        $(aws ecr get-login --no-include-email)
+        aws ecr get-login-password | docker login --username AWS --password-stdin ${ECR_REGISTRY}
         docker push ${ECR_IMAGE_PREFIX}/${app}
     done
 }

--- a/walkthroughs/howto-http-headers/deploy.sh
+++ b/walkthroughs/howto-http-headers/deploy.sh
@@ -19,13 +19,14 @@ fi
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
 PROJECT_NAME="howto-http-headers"
-ECR_IMAGE_PREFIX=${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/${PROJECT_NAME}
+ECR_REGISTRY=${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com
+ECR_IMAGE_PREFIX=${ECR_REGISTRY}/${PROJECT_NAME}
 
 deploy_images() {
     for app in colorapp feapp; do
         aws ecr describe-repositories --repository-name $PROJECT_NAME/$app >/dev/null 2>&1 || aws ecr create-repository --repository-name $PROJECT_NAME/$app
         docker build -t ${ECR_IMAGE_PREFIX}/${app} ${DIR}/${app}
-        $(aws ecr get-login --no-include-email)
+        aws ecr get-login-password | docker login --username AWS --password-stdin ${ECR_REGISTRY}
         docker push ${ECR_IMAGE_PREFIX}/${app}
     done
 }

--- a/walkthroughs/howto-http-retries/deploy.sh
+++ b/walkthroughs/howto-http-retries/deploy.sh
@@ -19,13 +19,14 @@ fi
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
 PROJECT_NAME="howto-http-retries"
-ECR_IMAGE_PREFIX=${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/${PROJECT_NAME}
+ECR_REGISTRY=${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com
+ECR_IMAGE_PREFIX=${ECR_REGISTRY}/${PROJECT_NAME}
 
 deploy_images() {
     for app in colorapp feapp; do
         aws ecr describe-repositories --repository-name $PROJECT_NAME/$app >/dev/null 2>&1 || aws ecr create-repository --repository-name $PROJECT_NAME/$app
         docker build -t ${ECR_IMAGE_PREFIX}/${app} ${DIR}/${app}
-        $(aws ecr get-login --no-include-email)
+        aws ecr get-login-password | docker login --username AWS --password-stdin ${ECR_REGISTRY}
         docker push ${ECR_IMAGE_PREFIX}/${app}
     done
 }

--- a/walkthroughs/howto-http2/deploy.sh
+++ b/walkthroughs/howto-http2/deploy.sh
@@ -28,14 +28,15 @@ if [ -z $KEY_PAIR ]; then
 fi
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
-ECR_IMAGE_PREFIX=${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/${PROJECT_NAME}
+ECR_REGISTRY=${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com
+ECR_IMAGE_PREFIX=${ECR_REGISTRY}/${PROJECT_NAME}
 
 deploy_images() {
     echo "Deploying Color Client and Color Server images to ECR..."
     for app in color_client color_server; do
         aws ecr describe-repositories --repository-name ${PROJECT_NAME}/${app} >/dev/null 2>&1 || aws ecr create-repository --repository-name ${PROJECT_NAME}/${app}
         docker build -t ${ECR_IMAGE_PREFIX}/${app} ${DIR}/${app} --build-arg GO_PROXY=${GO_PROXY:-"https://proxy.golang.org"}
-        $(aws ecr get-login --no-include-email)
+        aws ecr get-login-password | docker login --username AWS --password-stdin ${ECR_REGISTRY}
         docker push ${ECR_IMAGE_PREFIX}/${app}
     done
 }

--- a/walkthroughs/howto-k8s-alb/deploy.sh
+++ b/walkthroughs/howto-k8s-alb/deploy.sh
@@ -22,7 +22,8 @@ PROJECT_NAME="$(basename ${DIR})"
 APP_NAMESPACE=${PROJECT_NAME}
 MESH_NAME=${PROJECT_NAME}
 
-ECR_IMAGE_PREFIX="${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/${PROJECT_NAME}"
+ECR_REGISTRY="${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
+ECR_IMAGE_PREFIX="${ECR_REGISTRY}/${PROJECT_NAME}"
 FRONT_APP_IMAGE="${ECR_IMAGE_PREFIX}/feapp"
 COLOR_APP_IMAGE="${ECR_IMAGE_PREFIX}/colorapp"
 
@@ -30,7 +31,7 @@ deploy_images() {
     for app in colorapp feapp; do
         aws ecr describe-repositories --repository-name $PROJECT_NAME/$app >/dev/null 2>&1 || aws ecr create-repository --repository-name $PROJECT_NAME/$app
         docker build -t ${ECR_IMAGE_PREFIX}/${app} ${DIR}/${app}
-        $(aws ecr get-login --no-include-email)
+        aws ecr get-login-password | docker login --username AWS --password-stdin ${ECR_REGISTRY}
         docker push ${ECR_IMAGE_PREFIX}/${app}
     done
 }

--- a/walkthroughs/howto-k8s-cloudmap/deploy.sh
+++ b/walkthroughs/howto-k8s-cloudmap/deploy.sh
@@ -23,7 +23,8 @@ APP_NAMESPACE=${PROJECT_NAME}
 MESH_NAME=${PROJECT_NAME}
 CLOUDMAP_NAMESPACE="${PROJECT_NAME}.pvt.aws.local"
 
-ECR_IMAGE_PREFIX="${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/${PROJECT_NAME}"
+ECR_REGISTRY="${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
+ECR_IMAGE_PREFIX="${ECR_REGISTRY}/${PROJECT_NAME}"
 FRONT_APP_IMAGE="${ECR_IMAGE_PREFIX}/feapp"
 COLOR_APP_IMAGE="${ECR_IMAGE_PREFIX}/colorapp"
 
@@ -55,7 +56,7 @@ deploy_images() {
     for app in colorapp feapp; do
         aws ecr describe-repositories --repository-name $PROJECT_NAME/$app >/dev/null 2>&1 || aws ecr create-repository --repository-name $PROJECT_NAME/$app
         docker build -t ${ECR_IMAGE_PREFIX}/${app} ${DIR}/${app}
-        $(aws ecr get-login --no-include-email)
+        aws ecr get-login-password | docker login --username AWS --password-stdin ${ECR_REGISTRY}
         docker push ${ECR_IMAGE_PREFIX}/${app}
     done
 }

--- a/walkthroughs/howto-k8s-cross-cluster/deploy.sh
+++ b/walkthroughs/howto-k8s-cross-cluster/deploy.sh
@@ -38,7 +38,8 @@ APP_NAMESPACE=${PROJECT_NAME}
 MESH_NAME=${PROJECT_NAME}
 CLOUDMAP_NAMESPACE="${PROJECT_NAME}.pvt.aws.local"
 
-ECR_IMAGE_PREFIX="${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/${PROJECT_NAME}"
+ECR_REGISTRY="${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
+ECR_IMAGE_PREFIX="${ECR_REGISTRY}/${PROJECT_NAME}"
 FRONT_APP_IMAGE="${ECR_IMAGE_PREFIX}/feapp"
 COLOR_APP_IMAGE="${ECR_IMAGE_PREFIX}/colorapp"
 
@@ -46,7 +47,7 @@ deploy_images() {
     for app in colorapp feapp; do
         aws ecr describe-repositories --repository-name $PROJECT_NAME/$app >/dev/null 2>&1 || aws ecr create-repository --repository-name $PROJECT_NAME/$app
         docker build -t ${ECR_IMAGE_PREFIX}/${app} ${DIR}/${app}
-        $(aws ecr get-login --no-include-email)
+        aws ecr get-login-password | docker login --username AWS --password-stdin ${ECR_REGISTRY}
         docker push ${ECR_IMAGE_PREFIX}/${app}
     done
 }

--- a/walkthroughs/howto-k8s-fargate/deploy.sh
+++ b/walkthroughs/howto-k8s-fargate/deploy.sh
@@ -22,7 +22,8 @@ PROJECT_NAME="$(basename ${DIR})"
 APP_NAMESPACE=${PROJECT_NAME}
 MESH_NAME=${PROJECT_NAME}
 
-ECR_IMAGE_PREFIX="${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/${PROJECT_NAME}"
+ECR_REGISTRY="${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
+ECR_IMAGE_PREFIX="${ECR_REGISTRY}/${PROJECT_NAME}"
 FRONT_APP_IMAGE="${ECR_IMAGE_PREFIX}/feapp:$(git log -1 --format=%h src/feapp)"
 COLOR_APP_IMAGE="${ECR_IMAGE_PREFIX}/colorapp:$(git log -1 --format=%h src/colorapp)"
 
@@ -66,7 +67,7 @@ deploy_images() {
         aws ecr describe-repositories --repository-name ${PROJECT_NAME}/${f} >/dev/null 2>&1 || aws ecr create-repository --repository-name ${PROJECT_NAME}/${f}
     done
 
-    $(aws ecr get-login --no-include-email)
+    aws ecr get-login-password | docker login --username AWS --password-stdin ${ECR_REGISTRY}
     docker build --build-arg GOPROXY=${GOPROXY} -t ${COLOR_APP_IMAGE} ${DIR}/src/colorapp && docker push ${COLOR_APP_IMAGE}
     docker build --build-arg GOPROXY=${GOPROXY} -t ${FRONT_APP_IMAGE} ${DIR}/src/feapp && docker push ${FRONT_APP_IMAGE}
 }

--- a/walkthroughs/howto-k8s-grpc/deploy.sh
+++ b/walkthroughs/howto-k8s-grpc/deploy.sh
@@ -22,7 +22,8 @@ PROJECT_NAME="howto-k8s-grpc"
 APP_NAMESPACE=${PROJECT_NAME}
 MESH_NAME=${PROJECT_NAME}
 CLOUDMAP_NAMESPACE="${APP_NAMESPACE}.svc.cluster.local"
-ECR_IMAGE_PREFIX="${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/${PROJECT_NAME}"
+ECR_REGISTRY="${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
+ECR_IMAGE_PREFIX="${ECR_REGISTRY}/${PROJECT_NAME}"
 CLIENT_APP_IMAGE="${ECR_IMAGE_PREFIX}/color_client"
 COLOR_APP_IMAGE="${ECR_IMAGE_PREFIX}/color_server"
 
@@ -54,7 +55,7 @@ deploy_images() {
     for app in color_client color_server; do
         aws ecr describe-repositories --repository-name $PROJECT_NAME/$app >/dev/null 2>&1 || aws ecr create-repository --repository-name $PROJECT_NAME/$app
         docker build -t ${ECR_IMAGE_PREFIX}/${app} ${DIR}/${app} --build-arg GO_PROXY=${GO_PROXY:-"https://proxy.golang.org"}
-        $(aws ecr get-login --no-include-email)
+        docker login --username AWS --password-stdin ${ECR_REGISTRY}
         docker push ${ECR_IMAGE_PREFIX}/${app}
     done
 }

--- a/walkthroughs/howto-k8s-http-headers/deploy.sh
+++ b/walkthroughs/howto-k8s-http-headers/deploy.sh
@@ -22,7 +22,8 @@ PROJECT_NAME="howto-k8s-http-headers"
 APP_NAMESPACE=${PROJECT_NAME}
 MESH_NAME=${PROJECT_NAME}
 
-ECR_IMAGE_PREFIX="${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/${PROJECT_NAME}"
+ECR_REGISTRY="${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
+ECR_IMAGE_PREFIX="${ECR_REGISTRY}/${PROJECT_NAME}"
 FRONT_APP_IMAGE="${ECR_IMAGE_PREFIX}/feapp"
 COLOR_APP_IMAGE="${ECR_IMAGE_PREFIX}/colorapp"
 
@@ -54,7 +55,7 @@ deploy_images() {
     for app in colorapp feapp; do
         aws ecr describe-repositories --repository-name $PROJECT_NAME/$app >/dev/null 2>&1 || aws ecr create-repository --repository-name $PROJECT_NAME/$app
         docker build -t ${ECR_IMAGE_PREFIX}/${app} ${DIR}/${app}
-        $(aws ecr get-login --no-include-email)
+        docker login --username AWS --password-stdin ${ECR_REGISTRY}
         docker push ${ECR_IMAGE_PREFIX}/${app}
     done
 }

--- a/walkthroughs/howto-k8s-http2/deploy.sh
+++ b/walkthroughs/howto-k8s-http2/deploy.sh
@@ -22,7 +22,8 @@ PROJECT_NAME="howto-k8s-http2"
 APP_NAMESPACE=${PROJECT_NAME}
 MESH_NAME=${PROJECT_NAME}
 CLOUDMAP_NAMESPACE="${APP_NAMESPACE}.svc.cluster.local"
-ECR_IMAGE_PREFIX="${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/${PROJECT_NAME}"
+ECR_REGISTRY="${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
+ECR_IMAGE_PREFIX="${ECR_REGISTRY}/${PROJECT_NAME}"
 CLIENT_APP_IMAGE="${ECR_IMAGE_PREFIX}/color_client"
 COLOR_APP_IMAGE="${ECR_IMAGE_PREFIX}/color_server"
 
@@ -54,7 +55,7 @@ deploy_images() {
     for app in color_client color_server; do
         aws ecr describe-repositories --repository-name $PROJECT_NAME/$app >/dev/null 2>&1 || aws ecr create-repository --repository-name $PROJECT_NAME/$app
         docker build -t ${ECR_IMAGE_PREFIX}/${app} ${DIR}/${app} --build-arg GO_PROXY=${GO_PROXY:-"https://proxy.golang.org"}
-        $(aws ecr get-login --no-include-email)
+        docker login --username AWS --password-stdin ${ECR_REGISTRY}
         docker push ${ECR_IMAGE_PREFIX}/${app}
     done
 }

--- a/walkthroughs/howto-k8s-retry-policy/deploy.sh
+++ b/walkthroughs/howto-k8s-retry-policy/deploy.sh
@@ -22,7 +22,8 @@ PROJECT_NAME="howto-k8s-retry-policy"
 APP_NAMESPACE=${PROJECT_NAME}
 MESH_NAME=${PROJECT_NAME}
 
-ECR_IMAGE_PREFIX="${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/${PROJECT_NAME}"
+ECR_REGISTRY="${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
+ECR_IMAGE_PREFIX="${ECR_REGISTRY}/${PROJECT_NAME}"
 FRONT_APP_IMAGE="${ECR_IMAGE_PREFIX}/feapp"
 COLOR_APP_IMAGE="${ECR_IMAGE_PREFIX}/colorapp"
 
@@ -53,7 +54,7 @@ deploy_images() {
     for app in colorapp feapp; do
         aws ecr describe-repositories --repository-name $PROJECT_NAME/$app >/dev/null 2>&1 || aws ecr create-repository --repository-name $PROJECT_NAME/$app
         docker build -t ${ECR_IMAGE_PREFIX}/${app} ${DIR}/${app}
-        $(aws ecr get-login --no-include-email)
+        docker login --username AWS --password-stdin ${ECR_REGISTRY}
         docker push ${ECR_IMAGE_PREFIX}/${app}
     done
 }

--- a/walkthroughs/howto-timeout-policy/deploy.sh
+++ b/walkthroughs/howto-timeout-policy/deploy.sh
@@ -19,13 +19,14 @@ fi
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
 PROJECT_NAME="howto-timeout-policy"
-ECR_IMAGE_PREFIX=${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/${PROJECT_NAME}
+ECR_REGISTRY=${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com
+ECR_IMAGE_PREFIX=${ECR_REGISTRY}/${PROJECT_NAME}
 
 deploy_images() {
     for app in colorapp feapp; do
         aws ecr describe-repositories --repository-name $PROJECT_NAME/$app >/dev/null 2>&1 || aws ecr create-repository --repository-name $PROJECT_NAME/$app
         docker build -t ${ECR_IMAGE_PREFIX}/${app} ${DIR}/${app}
-        $(aws ecr get-login --no-include-email)
+        docker login --username AWS --password-stdin ${ECR_REGISTRY}
         docker push ${ECR_IMAGE_PREFIX}/${app}
     done
 }

--- a/walkthroughs/howto-tls-file-provided/src/colorteller/deploy.sh
+++ b/walkthroughs/howto-tls-file-provided/src/colorteller/deploy.sh
@@ -10,11 +10,12 @@ fi
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 
-IMAGE="${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/${COLOR_TELLER_IMAGE_NAME}:latest"
+ECR_REGISTRY="${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
+IMAGE="${ECR_REGISTRY}/${COLOR_TELLER_IMAGE_NAME}:latest"
 
 # build
 docker build -t $IMAGE $DIR --build-arg GO_PROXY=${GO_PROXY:-"https://proxy.golang.org"}
 
 # push
-$(aws ecr get-login --no-include-email)
+docker login --username AWS --password-stdin ${ECR_REGISTRY}
 docker push $IMAGE

--- a/walkthroughs/howto-tls-file-provided/src/customEnvoyImage/deploy.sh
+++ b/walkthroughs/howto-tls-file-provided/src/customEnvoyImage/deploy.sh
@@ -15,13 +15,16 @@ fi
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 
-$(aws ecr get-login --no-include-email --registry-id 840364872350)
+ENVOY_ACCOUNT_PASSWORD="$(aws ecr get-authorization-token --registry-ids 840364872350 --query 'authorizationData[0].authorizationToken' --output text)"
+ENVOY_ACCOUNT_ECR_REGISTRY="840364872350.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
+echo "$ENVOY_ACCOUNT_PASSWORD" | docker login --username AWS --password-stdin ${ENVOY_ACCOUNT_ECR_REGISTRY}
 
-IMAGE="${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/${COLOR_APP_ENVOY_IMAGE_NAME}:latest"
+ECR_REGISTRY="${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
+IMAGE="${ECR_REGISTRY}/${COLOR_APP_ENVOY_IMAGE_NAME}:latest"
 
 # build
 docker build -t $IMAGE $DIR --build-arg ENVOY_IMAGE=$ENVOY_IMAGE
 
 # push
-$(aws ecr get-login --no-include-email)
+docker login --username AWS --password-stdin ${ECR_REGISTRY}
 docker push $IMAGE

--- a/walkthroughs/howto-tls-file-provided/src/gateway/deploy.sh
+++ b/walkthroughs/howto-tls-file-provided/src/gateway/deploy.sh
@@ -10,11 +10,12 @@ fi
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 
-IMAGE="${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/${GATEWAY_IMAGE_NAME}:latest"
+ECR_REGISTRY="${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
+IMAGE="${ECR_REGISTRY}/${GATEWAY_IMAGE_NAME}:latest"
 
 # build
 docker build -t $IMAGE $DIR --build-arg GO_PROXY=${GO_PROXY:-"https://proxy.golang.org"}
 
 # push
-$(aws ecr get-login --no-include-email)
+docker login --username AWS --password-stdin ${ECR_REGISTRY}
 docker push $IMAGE

--- a/walkthroughs/tls-with-acm/src/colorteller/deploy.sh
+++ b/walkthroughs/tls-with-acm/src/colorteller/deploy.sh
@@ -10,11 +10,12 @@ fi
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 
-IMAGE="${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/${COLOR_TELLER_IMAGE_NAME}:latest"
+ECR_REGISTRY="${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
+IMAGE="${ECR_REGISTRY}/${COLOR_TELLER_IMAGE_NAME}:latest"
 
 # build
 docker build -t $IMAGE $DIR --build-arg GO_PROXY=${GO_PROXY:-"https://proxy.golang.org"}
 
 # push
-$(aws ecr get-login --no-include-email)
+docker login --username AWS --password-stdin ${ECR_REGISTRY}
 docker push $IMAGE

--- a/walkthroughs/tls-with-acm/src/gateway/deploy.sh
+++ b/walkthroughs/tls-with-acm/src/gateway/deploy.sh
@@ -10,11 +10,12 @@ fi
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 
-IMAGE="${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/${GATEWAY_IMAGE_NAME}:latest"
+ECR_REGISTRY="${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
+IMAGE="${ECR_REGISTRY}/${GATEWAY_IMAGE_NAME}:latest"
 
 # build
 docker build -t $IMAGE $DIR --build-arg GO_PROXY=${GO_PROXY:-"https://proxy.golang.org"}
 
 # push
-$(aws ecr get-login --no-include-email)
+docker login --username AWS --password-stdin ${ECR_REGISTRY}
 docker push $IMAGE


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

I'd like to use this repository with aws-cli v2.
ref: https://docs.aws.amazon.com/cli/latest/userguide/cliv2-migration.html#cliv2-migration-ecr-get-login

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
