### PR TITLE
Changed app link to point to new location.

### DIFF
--- a/walkthroughs/eks/base.md
+++ b/walkthroughs/eks/base.md
@@ -85,7 +85,7 @@ kubectl api-resources --api-group=appmesh.k8s.aws
 
 ## The application
 
-We use the [colorapp](https://github.com/awslabs/aws-app-mesh-examples/tree/master/examples/apps/colorapp) to demonstrate the usage of App Mesh with EKS.
+We use the [howto-k8s-colorapp](https://github.com/aws/aws-app-mesh-examples/tree/master/walkthroughs/howto-k8s-cloudmap) to demonstrate the usage of App Mesh with EKS.
 
 Install the example application from the location where you checked out the [AWS App Mesh Controller For Kubernetes](https://github.com/aws/aws-app-mesh-controller-for-k8s):
 


### PR DESCRIPTION
I changed the link from to point to the to the color app in the examples.

*Issue #, if available:*
#268 

*Description of changes:*
Removed link to [aws-app-mesh-contoller-for-k8s](https://github.com/aws/aws-app-mesh-controller-for-k8s) to [howto-k8s-cloudmap](https://github.com/aws/aws-app-mesh-examples/tree/master/walkthroughs/howto-k8s-cloudmap).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
