### PR TITLE
Using customer CW Agent image that runs as user 1337

### DIFF
--- a/walkthroughs/howto-ingress-gateway/README.md
+++ b/walkthroughs/howto-ingress-gateway/README.md
@@ -121,6 +121,7 @@ export MESH_NAME=ColorApp-Ingress
 export ENVOY_IMAGE=<get the latest from https://docs.aws.amazon.com/app-mesh/latest/userguide/envoy.html>
 export SERVICES_DOMAIN="default.svc.cluster.local"
 export COLOR_TELLER_IMAGE_NAME="howto-ingress/colorteller"
+export CLOUDWATCH_AGENT_IMAGE_NAME="howto-ingress/aws-app-mesh-cloudwatch-agent"
 ```
 
 ## Step 3: Generate Certificate from ACM
@@ -213,15 +214,17 @@ Next, create the ECS cluster and ECR repositories.
 ./infrastructure/ecr-repositories.sh
 ```
 
-Finally, build and deploy the colorteller image.
+Finally, build and deploy the colorteller and cloudwatch agent images.
 
 ```bash
 ./src/colorteller/deploy.sh
+./src/cloudwatch-agent/deploy.sh
 ```
 Note that the example apps use go modules. If you have trouble accessing https://proxy.golang.org during the deployment you can override the GOPROXY by setting `GO_PROXY=direct`
 
 ```bash
 GO_PROXY=direct ./src/colorteller/deploy.sh
+GO_PROXY=direct ./src/cloudwatch-agent/deploy.sh
 ```
 
 ## Step 5: Create a Mesh

--- a/walkthroughs/howto-ingress-gateway/infrastructure/ecr-repositories.sh
+++ b/walkthroughs/howto-ingress-gateway/infrastructure/ecr-repositories.sh
@@ -10,4 +10,5 @@ aws --region "${AWS_DEFAULT_REGION}" \
     --capabilities CAPABILITY_IAM \
     --template-file "${DIR}/ecr-repositories.yaml" \
     --parameter-overrides \
-    ColorTellerImageName="${COLOR_TELLER_IMAGE_NAME}"
+    ColorTellerImageName="${COLOR_TELLER_IMAGE_NAME}" \
+    CloudWatchAgentImageName="${CLOUDWATCH_AGENT_IMAGE_NAME}"

--- a/walkthroughs/howto-ingress-gateway/infrastructure/ecr-repositories.yaml
+++ b/walkthroughs/howto-ingress-gateway/infrastructure/ecr-repositories.yaml
@@ -4,9 +4,18 @@ Parameters:
     Description: The name for the color teller image
     Type: String
 
+  CloudWatchAgentImageName:
+    Description: The name for the custom App Mesh CloudWatch Agent image
+    Type: String
+
 Resources:
 
   ColorTellerRepository:
     Type: AWS::ECR::Repository
     Properties:
       RepositoryName: !Ref ColorTellerImageName
+
+  CloudWatchAgentRepository:
+    Type: AWS::ECR::Repository
+    Properties:
+      RepositoryName: !Ref CloudWatchAgentImageName

--- a/walkthroughs/howto-ingress-gateway/infrastructure/ecs-service.sh
+++ b/walkthroughs/howto-ingress-gateway/infrastructure/ecs-service.sh
@@ -15,6 +15,7 @@ aws --region "${AWS_DEFAULT_REGION}" \
     AppMeshMeshName="${MESH_NAME}" \
     EnvoyImage="${ENVOY_IMAGE}" \
     ColorTellerImageName="${COLOR_TELLER_IMAGE_NAME}" \
+    CloudWatchAgentImageName="${CLOUDWATCH_AGENT_IMAGE_NAME}" \
     LoadBalancerCertificateArn="${CERTIFICATE_ARN}"
 
 print_bastion() {

--- a/walkthroughs/howto-ingress-gateway/infrastructure/ecs-service.yaml
+++ b/walkthroughs/howto-ingress-gateway/infrastructure/ecs-service.yaml
@@ -20,6 +20,10 @@ Parameters:
     Description: The name for the color teller image
     Type: String
 
+  CloudWatchAgentImageName:
+    Description: The name for the custom App Mesh CloudWatch Agent image
+    Type: String
+
   LoadBalancerCertificateArn:
     Description: NLB TLS Certificate Arn
     Type: String
@@ -584,8 +588,9 @@ Resources:
             - Name: 'STATSD_PORT'
               Value: '8125'
         - Name: 'cw-agent'
-          Image: 'amazon/cloudwatch-agent'
+          Image: !Sub '${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/${CloudWatchAgentImageName}'
           Essential: true
+          User: '1337'
           PortMappings:
             - ContainerPort: 8125
               Protocol: 'udp'
@@ -593,7 +598,7 @@ Resources:
             - Name: CW_CONFIG_CONTENT
               Value:
                 Fn::Sub:
-                  - '{ "logs": { "metrics_collected": {"emf": {} }}, "metrics": { "metrics_collected": { "statsd": {}}, "namespace": "${MetricNamespace}"}}'
+                  - '{ \"metrics\": { \"namespace\":\"${MetricNamespace}\", \"metrics_collected\": { \"statsd\": { \"metrics_aggregation_interval\": 0}}}}'
                   - MetricNamespace:
                       Fn::Join:
                       - '/'

--- a/walkthroughs/howto-ingress-gateway/src/cloudwatch-agent/Dockerfile
+++ b/walkthroughs/howto-ingress-gateway/src/cloudwatch-agent/Dockerfile
@@ -1,0 +1,19 @@
+FROM amazonlinux
+
+# See https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/download-cloudwatch-agent-commandline.html
+RUN yum install -y \
+    shadow-utils \
+    https://s3.amazonaws.com/amazoncloudwatch-agent/amazon_linux/amd64/latest/amazon-cloudwatch-agent.rpm
+
+# start-amazon-cloudwatch-agent uses the environment to generate a config file
+# see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/create-cloudwatch-agent-configuration-file-wizard.html.
+# However, this file cannot be written without providing permissions to uid 1337 that is
+# used by containers in the context of App Mesh. 
+# NOTICE: copied from https://github.com/istio/istio/blob/master/docker/Dockerfile.base
+RUN useradd -m --uid 1337 sidecar-agent && \
+    echo "sidecar-agent ALL=NOPASSWD: ALL" >> /etc/sudoers && \
+    chown -R sidecar-agent /opt/aws/amazon-cloudwatch-agent
+
+USER sidecar-agent
+ENV RUN_IN_CONTAINER="True"
+ENTRYPOINT ["/opt/aws/amazon-cloudwatch-agent/bin/start-amazon-cloudwatch-agent"]

--- a/walkthroughs/howto-ingress-gateway/src/cloudwatch-agent/deploy.sh
+++ b/walkthroughs/howto-ingress-gateway/src/cloudwatch-agent/deploy.sh
@@ -3,16 +3,15 @@
 
 set -ex
 
-if [ -z $COLOR_TELLER_IMAGE_NAME ]; then
-    echo "COLOR_TELLER_IMAGE_NAME environment variable is not set"
+if [ -z $CLOUDWATCH_AGENT_IMAGE_NAME ]; then
+    echo "CLOUDWATCH_AGENT_IMAGE_NAME environment variable is not set"
     exit 1
 fi
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 
 ECR_URL="${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
-
-IMAGE="${ECR_URL}/${COLOR_TELLER_IMAGE_NAME}:latest"
+IMAGE="${ECR_URL}/${CLOUDWATCH_AGENT_IMAGE_NAME}:latest"
 
 # build
 docker build -t $IMAGE $DIR --build-arg GO_PROXY=${GO_PROXY:-"https://proxy.golang.org"}


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*

The CloudWatch Agent image on docker hub doesn't run as user 1337, thus the metric reporting goes through Envoy. 

This PR will deploy custom CW agent that will run as user 1337.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
