### PR TITLE
Fix the deploy script for the servicediscovery-cloudmap demo and did …

### DIFF
--- a/walkthroughs/howto-servicediscovery-cloudmap/README.md
+++ b/walkthroughs/howto-servicediscovery-cloudmap/README.md
@@ -6,14 +6,14 @@ This is a demo of using Cloud Map for service discovery in App Mesh.
 
 ## Prerequisites
 
-1. You have version 1.16.124 or higher of the AWS CLI (https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html) installed.
-2. You have cloned the github.com/aws/aws-app-mesh-examples (https://github.com/aws/aws-app-mesh-examples) repo and changed directory to the project root.
+1. You have version 1.16.124 or higher of the [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html) installed.
+2. You have cloned the [github.com/aws/aws-app-mesh-examples](https://github.com/aws/aws-app-mesh-examples) repo and changed directory to the project root.
 
 ## Environment
 
 Set or export the following environment variables with appropriate values for your account, etc.
 
-```
+```bash
 # Your AWS account ID
 export AWS_ACCOUNT_ID=999999999999
 
@@ -25,13 +25,14 @@ export RESOURCE_PREFIX=demo
 ```
 
 ## Publish application container images to ECR
+
 Run `walkthroughs/howto-servicediscovery-cloudmap/deploy-images.sh`
 
 ## Run the Demo
 
 Once your environment is ready, run `walkthroughs/howto-servicediscovery-cloudmap/deploy.sh`
 
-```
+```bash
 $ walkthroughs/howto-servicediscovery-cloudmap/deploy.sh
 deploy vpc...
 Waiting for changeset to be created..
@@ -48,8 +49,7 @@ http://demo-Public-1G1K8NGKE7VH6-369254194.us-west-1.elb.amazonaws.com
 
 Save the endpoint in a variable and curl it to see responses:
 
+```bash
+app=http://demo-Public-1G1K8NGKE7VH6-369254194.us-west-1.elb.amazonaws.com
+curl $app/color
 ```
-$ app=http://demo-Public-1G1K8NGKE7VH6-369254194.us-west-1.elb.amazonaws.com
-$ curl $app/color
-$ ...
-

--- a/walkthroughs/howto-servicediscovery-cloudmap/deploy.sh
+++ b/walkthroughs/howto-servicediscovery-cloudmap/deploy.sh
@@ -19,8 +19,8 @@ fi
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 APP_DIR="${DIR}/../../examples/apps/colorapp"
-COLOR_GATEWAY_IMAGE=${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/color/gateway
-COLOR_TELLER_IMAGE=${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/color/teller
+COLOR_GATEWAY_IMAGE=${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/gateway
+COLOR_TELLER_IMAGE=${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/colorteller
 
 deploy_vpc() {
     aws cloudformation deploy \


### PR DESCRIPTION
…some minor README linting

*Issue #, if available:* N/A

*Description of changes:*

The Cloudmap Demo depends on some container images created in the colorapp demo. The repository in the `deploy` script was pointing at the wrong images. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
