### PR TITLE
Add v1beta2 manifest for k8s ingress ALB

### DIFF
--- a/walkthroughs/howto-k8s-alb/README.md
+++ b/walkthroughs/howto-k8s-alb/README.md
@@ -7,6 +7,8 @@ This example shows how to use [ALB Ingress Controller](https://github.com/kubern
 - [Walkthrough: App Mesh with EKS](../eks/)
 - [Walkthrough: ALB Ingress Controller](https://kubernetes-sigs.github.io/aws-alb-ingress-controller/guide/walkthrough/echoserver/)
 
+Note: Only [deploy the ALB Ingress Controller](https://kubernetes-sigs.github.io/aws-alb-ingress-controller/guide/walkthrough/echoserver/#deploy-the-alb-ingress-controller) and rest this example service will replace the echoserver in the ALB Ingress Controller link provider
+
 ## Setup
 
 1. Clone this repository and navigate to the walkthrough/howto-k8s-alb folder, all commands will be run from this location
@@ -25,4 +27,62 @@ This example shows how to use [ALB Ingress Controller](https://github.com/kubern
 5. Deploy
     ```.
     ./deploy.sh
+    ```
+
+## Usage
+
+Check the events of the ingress to see what has occur.
+
+    ```bash
+    kubectl describe ing -n howto-k8s-alb color
+    ```
+
+You should see similar to the following.
+    ```
+    Name:             color
+    Namespace:        howto-k8s-alb
+    Address:          80113f18-howtok8salb-color-0f20-319733316.us-west-2.elb.amazonaws.com
+    Default backend:  default-http-backend:80 (<none>)
+    Rules:
+      Host  Path  Backends
+      ----  ----  --------
+      *
+            /color   color:8080 (192.168.16.27:8080,192.168.59.249:8080)
+    Annotations:
+      kubectl.kubernetes.io/last-applied-configuration:  {"apiVersion":"extensions/v1beta1","kind":"Ingress","metadata":{"annotations":{"alb.ingress.kubernetes.io/healthcheck-path":"/ping","alb.ingress.kubernetes.io/scheme":"internet-facing","alb.ingress.kubernetes.io/target-type":"ip","kubernetes.io/ingress.class":"alb"},"name":"color","namespace":"howto-k8s-alb"},"spec":{"rules":[{"http":{"paths":[{"backend":{"serviceName":"color","servicePort":8080},"path":"/color"}]}}]}}
+      kubernetes.io/ingress.class:                 alb
+      alb.ingress.kubernetes.io/healthcheck-path:  /ping
+      alb.ingress.kubernetes.io/scheme:            internet-facing
+      alb.ingress.kubernetes.io/target-type:       ip
+    Events:
+      Type    Reason  Age    From                    Message
+      ----    ------  ----   ----                    -------
+      Normal  CREATE  11m    alb-ingress-controller  LoadBalancer 80113f18-howtok8salb-color-0f20 created, ARN: arn:aws:elasticloadbalancing:us-west-2:669977933099:loadbalancer/app/80113f18-howtok8salb-color-0f20/7c45f6fd4eefa871
+      Normal  CREATE  11m    alb-ingress-controller  rule 1 created with conditions [{    Field: "path-pattern",    PathPatternConfig: {      Values: ["/"]    }  }]
+      Normal  MODIFY  4m12s  alb-ingress-controller  rule 1 modified with conditions [{    Field: "path-pattern",    PathPatternConfig: {      Values: ["/color"]    }  }]
+     ```
+
+To check if the application is reachable via ALB Ingress Controller
+    ```
+    curl -v 80113f18-howtok8salb-color-0f20-319733316.us-west-2.elb.amazonaws.com/color
+    ```
+
+You should see similar to the following.
+    ```
+    *   Trying 34.208.158.34...
+    * TCP_NODELAY set
+    * Connected to 80113f18-howtok8salb-color-0f20-319733316.us-west-2.elb.amazonaws.com (34.208.158.34) port 80 (#0)
+    > GET /color HTTP/1.1> Host: 80113f18-howtok8salb-color-0f20-319733316.us-west-2.elb.amazonaws.com
+    > User-Agent: curl/7.61.1
+    > Accept: */*
+    >
+    < HTTP/1.1 200 OK
+    < Date: Sat, 09 May 2020 01:30:06 GMT
+    < Transfer-Encoding: chunked
+    < Connection: keep-alive
+    < server: envoy
+    < x-envoy-upstream-service-time: 0
+    <
+    * Connection #0 to host 80113f18-howtok8salb-color-0f20-319733316.us-west-2.elb.amazonaws.com left intact
+    blue
     ```

--- a/walkthroughs/howto-k8s-alb/deploy.sh
+++ b/walkthroughs/howto-k8s-alb/deploy.sh
@@ -25,6 +25,53 @@ MESH_NAME=${PROJECT_NAME}
 ECR_IMAGE_PREFIX="${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/${PROJECT_NAME}"
 FRONT_APP_IMAGE="${ECR_IMAGE_PREFIX}/feapp"
 COLOR_APP_IMAGE="${ECR_IMAGE_PREFIX}/colorapp"
+MANIFEST_VERSION="${1:-v1beta2}"
+
+error() {
+    echo $1
+    exit 1
+}
+
+check_k8s_virtualrouter() {
+    #check CRD
+    crd=$(kubectl get crd virtualrouters.appmesh.k8s.aws -o json )
+    if [ -z "$crd" ]; then
+        error "$PROJECT_NAME requires virtualrouters.appmesh.k8s.aws CRD to support HTTP. See https://github.com/aws/aws-app-mesh-controller-for-k8s/blob/master/CHANGELOG.md"
+    else
+        echo "CRD check passed!"
+    fi
+}
+
+check_k8s_virtualservice() {
+    #check CRD
+    crd=$(kubectl get crd virtualservices.appmesh.k8s.aws -o json | jq -r '.. | .http2? | select(. != null)')
+    if [ -z "$crd" ]; then
+        error "$PROJECT_NAME requires virtualservices.appmesh.k8s.aws CRD to support HTTP. See https://github.com/aws/aws-app-mesh-controller-for-k8s/blob/master/CHANGELOG.md#v030"
+    else
+        echo "CRD check passed!"
+    fi
+}
+
+check_appmesh_k8s() {
+    #check aws-app-mesh-controller version
+    currentver=$(kubectl get deployment -n appmesh-system appmesh-controller-manager -o json | jq -r ".spec.template.spec.containers[].image" | cut -f2 -d ':')
+
+    if [ "$MANIFEST_VERSION" = "v1beta2" ]; then
+        requiredver="v1.0.0"
+        check_k8s_virtualrouter
+    elif [ "$MANIFEST_VERSION" = "v1beta1" ]; then
+        requiredver="v0.3.0"
+        check_k8s_virtualservice
+    else
+        error "$PROJECT_NAME unexpected manifest version input: $MANIFEST_VERSION. Should be v1beta2 or v1beta1 based on the AppMesh controller version. See https://github.com/aws/aws-app-mesh-controller-for-k8s/blob/master/CHANGELOG.md"
+    fi
+
+    if [ "$(printf '%s\n' "$requiredver" "$currentver" | sort -V | head -n1)" = "$requiredver" ]; then
+        echo "aws-app-mesh-controller check passed! $currentver >= $requiredver"
+    else
+        error "$PROJECT_NAME requires aws-app-mesh-controller version >=$requiredver but found $currentver. See https://github.com/aws/aws-app-mesh-controller-for-k8s/blob/master/CHANGELOG.md"
+    fi
+}
 
 deploy_images() {
     for app in colorapp feapp; do
@@ -39,7 +86,7 @@ deploy_app() {
     EXAMPLES_OUT_DIR="${DIR}/_output/"
     mkdir -p ${EXAMPLES_OUT_DIR}
     eval "cat <<EOF
-$(<${DIR}/manifest.yaml.template)
+$(<${DIR}/${MANIFEST_VERSION}/manifest.yaml.template)
 EOF
 " >${EXAMPLES_OUT_DIR}/manifest.yaml
 
@@ -47,6 +94,7 @@ EOF
 }
 
 main() {
+    check_appmesh_k8s
     if [ -z $SKIP_IMAGES ]; then
         echo "deploy images..."
         deploy_images

--- a/walkthroughs/howto-k8s-alb/deploy.sh
+++ b/walkthroughs/howto-k8s-alb/deploy.sh
@@ -54,12 +54,12 @@ check_k8s_virtualservice() {
 
 check_appmesh_k8s() {
     #check aws-app-mesh-controller version
-    currentver=$(kubectl get deployment -n appmesh-system appmesh-controller-manager -o json | jq -r ".spec.template.spec.containers[].image" | cut -f2 -d ':')
-
     if [ "$MANIFEST_VERSION" = "v1beta2" ]; then
+        currentver=$(kubectl get deployment -n appmesh-system appmesh-controller-manager -o json | jq -r ".spec.template.spec.containers[].image" | cut -f2 -d ':'|tail -n1)
         requiredver="v1.0.0"
         check_k8s_virtualrouter
     elif [ "$MANIFEST_VERSION" = "v1beta1" ]; then
+        currentver=$(kubectl get deployment -n appmesh-system appmesh-controller -o json | jq -r ".spec.template.spec.containers[].image" | cut -f2 -d ':')
         requiredver="v0.3.0"
         check_k8s_virtualservice
     else

--- a/walkthroughs/howto-k8s-alb/v1beta1/manifest.yaml.template
+++ b/walkthroughs/howto-k8s-alb/v1beta1/manifest.yaml.template
@@ -1,0 +1,288 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    appmesh.k8s.aws/sidecarInjectorWebhook: enabled
+  name: ${APP_NAMESPACE}
+---
+apiVersion: appmesh.k8s.aws/v1beta1
+kind: Mesh
+metadata:
+  name: ${MESH_NAME}
+---
+apiVersion: appmesh.k8s.aws/v1beta1
+kind: VirtualNode
+metadata:
+  name: front
+  namespace: ${APP_NAMESPACE}
+spec:
+  meshName: ${MESH_NAME}
+  listeners:
+    - portMapping:
+        port: 8080
+        protocol: http
+      healthCheck:
+        protocol: http
+        path: '/ping'
+        healthyThreshold: 2
+        unhealthyThreshold: 2
+        timeoutMillis: 2000
+        intervalMillis: 5000
+  backends:
+    - virtualService:
+        virtualServiceName: color.${APP_NAMESPACE}.svc.cluster.local
+  serviceDiscovery:
+    dns:
+      hostName: front.${APP_NAMESPACE}.svc.cluster.local
+---
+apiVersion: appmesh.k8s.aws/v1beta1
+kind: VirtualNode
+metadata:
+  name: blue
+  namespace: ${APP_NAMESPACE}
+spec:
+  meshName: ${MESH_NAME}
+  listeners:
+    - portMapping:
+        port: 8080
+        protocol: http
+      healthCheck:
+        protocol: http
+        path: '/ping'
+        healthyThreshold: 2
+        unhealthyThreshold: 2
+        timeoutMillis: 2000
+        intervalMillis: 5000
+  serviceDiscovery:
+    dns:
+      hostName: color-blue.${APP_NAMESPACE}.svc.cluster.local
+---
+apiVersion: appmesh.k8s.aws/v1beta1
+kind: VirtualNode
+metadata:
+  name: green
+  namespace: ${APP_NAMESPACE}
+spec:
+  meshName: ${MESH_NAME}
+  listeners:
+    - portMapping:
+        port: 8080
+        protocol: http
+      healthCheck:
+        protocol: http
+        path: '/ping'
+        healthyThreshold: 2
+        unhealthyThreshold: 2
+        timeoutMillis: 2000
+        intervalMillis: 5000
+  serviceDiscovery:
+    dns:
+      hostName: color-green.${APP_NAMESPACE}.svc.cluster.local
+---
+apiVersion: appmesh.k8s.aws/v1beta1
+kind: VirtualService
+metadata:
+  name: color.${APP_NAMESPACE}.svc.cluster.local
+  namespace: ${APP_NAMESPACE}
+spec:
+  meshName: ${MESH_NAME}
+  virtualRouter:
+    name: color-router
+    listeners:
+      - portMapping:
+          port: 8080
+          protocol: http
+  routes:
+    - name: color-route
+      http:
+        match:
+          prefix: /
+        action:
+          weightedTargets:
+            - virtualNodeName: blue
+              weight: 1
+            - virtualNodeName: green
+              weight: 1
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: front
+  namespace: ${APP_NAMESPACE}
+  labels:
+    app: front
+spec:
+  ports:
+    - port: 8080
+      protocol: TCP
+  selector:
+    app: front
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: front
+  namespace: ${APP_NAMESPACE}
+spec:
+  replicas: 5
+  selector:
+    matchLabels:
+      app: front
+  template:
+    metadata:
+      annotations:
+        appmesh.k8s.aws/mesh: ${MESH_NAME}
+      labels:
+        app: front
+    spec:
+      containers:
+        - name: app
+          image: ${FRONT_APP_IMAGE}
+          ports:
+            - name: app-port
+              containerPort: 8080
+          readinessProbe:
+            httpGet:
+              path: /ping
+              port: app-port
+            initialDelaySeconds: 1
+            periodSeconds: 5
+            failureThreshold: 1
+          livenessProbe:
+            httpGet:
+              path: /ping
+              port: app-port
+            initialDelaySeconds: 1
+            periodSeconds: 5
+            failureThreshold: 1
+          env:
+            - name: "COLOR_HOST"
+              value: "color.${APP_NAMESPACE}.svc.cluster.local:8080"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: color-green
+  namespace: ${APP_NAMESPACE}
+  labels:
+    app: color
+    version: green
+spec:
+  ports:
+    - port: 8080
+      name: http
+  selector:
+    app: color
+    version: green
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: green
+  namespace: ${APP_NAMESPACE}
+  labels:
+    app: color
+    version: green
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: color
+      version: green
+  template:
+    metadata:
+      annotations:
+        appmesh.k8s.aws/mesh: ${MESH_NAME}
+      labels:
+        app: color
+        version: green
+    spec:
+      containers:
+        - name: app
+          image: ${COLOR_APP_IMAGE}
+          ports:
+            - containerPort: 8080
+          env:
+            - name: "COLOR"
+              value: "green"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: color-blue
+  namespace: ${APP_NAMESPACE}
+  labels:
+    app: color
+    version: blue
+spec:
+  ports:
+    - port: 8080
+      name: http
+  selector:
+    app: color
+    version: blue
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: blue
+  namespace: ${APP_NAMESPACE}
+  labels:
+    app: color
+    version: blue
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: color
+      version: blue
+  template:
+    metadata:
+      annotations:
+        appmesh.k8s.aws/mesh: ${MESH_NAME}
+      labels:
+        app: color
+        version: blue
+    spec:
+      containers:
+        - name: app
+          image: ${COLOR_APP_IMAGE}
+          ports:
+            - containerPort: 8080
+          env:
+            - name: "COLOR"
+              value: "blue"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: color
+  namespace: ${APP_NAMESPACE}
+  labels:
+    app: color
+spec:
+  ports:
+    - port: 8080
+      name: http
+  selector:
+    app: color
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: color
+  namespace: ${APP_NAMESPACE}
+  annotations:
+    kubernetes.io/ingress.class: alb
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/target-type: ip
+    alb.ingress.kubernetes.io/healthcheck-path: /color
+spec:
+  rules:
+  - http:
+      paths:
+      - backend:
+          serviceName: color
+          servicePort: 8080
+        path: /color

--- a/walkthroughs/howto-k8s-alb/v1beta2/manifest.yaml.template
+++ b/walkthroughs/howto-k8s-alb/v1beta2/manifest.yaml.template
@@ -2,22 +2,29 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  labels:
-    appmesh.k8s.aws/sidecarInjectorWebhook: enabled
   name: ${APP_NAMESPACE}
+  labels:
+    mesh: ${MESH_NAME}
+    appmesh.k8s.aws/sidecarInjectorWebhook: enabled
 ---
-apiVersion: appmesh.k8s.aws/v1beta1
+apiVersion: appmesh.k8s.aws/v1beta2
 kind: Mesh
 metadata:
   name: ${MESH_NAME}
+spec:
+  namespaceSelector:
+    matchLabels:
+      mesh: ${MESH_NAME}
 ---
-apiVersion: appmesh.k8s.aws/v1beta1
+apiVersion: appmesh.k8s.aws/v1beta2
 kind: VirtualNode
 metadata:
   name: front
   namespace: ${APP_NAMESPACE}
 spec:
-  meshName: ${MESH_NAME}
+  podSelector:
+    matchLabels:
+      app: front
   listeners:
     - portMapping:
         port: 8080
@@ -31,18 +38,22 @@ spec:
         intervalMillis: 5000
   backends:
     - virtualService:
-        virtualServiceName: color.${APP_NAMESPACE}.svc.cluster.local
+        virtualServiceRef:
+          name: color
   serviceDiscovery:
     dns:
-      hostName: front.${APP_NAMESPACE}.svc.cluster.local
+      hostname: front.${APP_NAMESPACE}.svc.cluster.local
 ---
-apiVersion: appmesh.k8s.aws/v1beta1
+apiVersion: appmesh.k8s.aws/v1beta2
 kind: VirtualNode
 metadata:
   name: blue
   namespace: ${APP_NAMESPACE}
 spec:
-  meshName: ${MESH_NAME}
+  podSelector:
+    matchLabels:
+      app: color
+      version: blue
   listeners:
     - portMapping:
         port: 8080
@@ -56,15 +67,18 @@ spec:
         intervalMillis: 5000
   serviceDiscovery:
     dns:
-      hostName: color-blue.${APP_NAMESPACE}.svc.cluster.local
+      hostname: color-blue.${APP_NAMESPACE}.svc.cluster.local
 ---
-apiVersion: appmesh.k8s.aws/v1beta1
+apiVersion: appmesh.k8s.aws/v1beta2
 kind: VirtualNode
 metadata:
   name: green
   namespace: ${APP_NAMESPACE}
 spec:
-  meshName: ${MESH_NAME}
+  podSelector:
+    matchLabels:
+      app: color
+      version: green
   listeners:
     - portMapping:
         port: 8080
@@ -78,31 +92,43 @@ spec:
         intervalMillis: 5000
   serviceDiscovery:
     dns:
-      hostName: color-green.${APP_NAMESPACE}.svc.cluster.local
+      hostname: color-green.${APP_NAMESPACE}.svc.cluster.local
 ---
-apiVersion: appmesh.k8s.aws/v1beta1
+apiVersion: appmesh.k8s.aws/v1beta2
 kind: VirtualService
 metadata:
-  name: color.${APP_NAMESPACE}.svc.cluster.local
+  name: color
   namespace: ${APP_NAMESPACE}
 spec:
-  meshName: ${MESH_NAME}
-  virtualRouter:
-    name: color-router
-    listeners:
-      - portMapping:
-          port: 8080
-          protocol: http
+  awsName: color.${APP_NAMESPACE}.svc.cluster.local
+  provider:
+    virtualRouter:
+      virtualRouterRef:
+        name: color-router
+
+---
+apiVersion: appmesh.k8s.aws/v1beta2
+kind: VirtualRouter
+metadata:
+  namespace: ${APP_NAMESPACE}
+  name: color-router
+spec:
+  listeners:
+    - portMapping:
+        port: 8080
+        protocol: http
   routes:
     - name: color-route
-      http:
+      httpRoute:
         match:
           prefix: /
         action:
           weightedTargets:
-            - virtualNodeName: blue
+            - virtualNodeRef:
+                name: blue
               weight: 1
-            - virtualNodeName: green
+            - virtualNodeRef:
+                name: green
               weight: 1
 ---
 apiVersion: v1
@@ -110,8 +136,6 @@ kind: Service
 metadata:
   name: front
   namespace: ${APP_NAMESPACE}
-  labels:
-    app: front
 spec:
   ports:
     - port: 8080
@@ -131,8 +155,6 @@ spec:
       app: front
   template:
     metadata:
-      annotations:
-        appmesh.k8s.aws/mesh: ${MESH_NAME}
       labels:
         app: front
     spec:
@@ -165,9 +187,6 @@ kind: Service
 metadata:
   name: color-green
   namespace: ${APP_NAMESPACE}
-  labels:
-    app: color
-    version: green
 spec:
   ports:
     - port: 8080
@@ -181,9 +200,6 @@ kind: Deployment
 metadata:
   name: green
   namespace: ${APP_NAMESPACE}
-  labels:
-    app: color
-    version: green
 spec:
   replicas: 1
   selector:
@@ -192,8 +208,6 @@ spec:
       version: green
   template:
     metadata:
-      annotations:
-        appmesh.k8s.aws/mesh: ${MESH_NAME}
       labels:
         app: color
         version: green
@@ -212,9 +226,6 @@ kind: Service
 metadata:
   name: color-blue
   namespace: ${APP_NAMESPACE}
-  labels:
-    app: color
-    version: blue
 spec:
   ports:
     - port: 8080
@@ -228,9 +239,6 @@ kind: Deployment
 metadata:
   name: blue
   namespace: ${APP_NAMESPACE}
-  labels:
-    app: color
-    version: blue
 spec:
   replicas: 1
   selector:
@@ -259,8 +267,6 @@ kind: Service
 metadata:
   name: color
   namespace: ${APP_NAMESPACE}
-  labels:
-    app: color
 spec:
   ports:
     - port: 8080
@@ -277,12 +283,12 @@ metadata:
     kubernetes.io/ingress.class: alb
     alb.ingress.kubernetes.io/scheme: internet-facing
     alb.ingress.kubernetes.io/target-type: ip
-    alb.ingress.kubernetes.io/healthcheck-path: /ping
+    alb.ingress.kubernetes.io/healthcheck-path: /color
 spec:
   rules:
-    - http:
-        paths:
-          - path: /
-            backend:
-              serviceName: front
-              servicePort: 8080
+  - http:
+      paths:
+      - backend:
+          serviceName: color
+          servicePort: 8080
+        path: /color


### PR DESCRIPTION
*Description of changes:*
- With the new version of AWS AppMesh k8s controller [1], updated:
  - v1beta2 example for k8s ingress alb example
- Validated the example with a v1beta2 controller
- The existing example was broken with wrong backed service name and path so fixed the v1beta1 example as well
- Added usage README

[1]https://github.com/aws/aws-app-mesh-controller-for-k8s/tree/v1beta2


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
