### PR TITLE
ingress-gateway: fix minor issues in shell script + cfn yaml

### DIFF
--- a/walkthroughs/howto-ingress-gateway/infrastructure/ecs-service.yaml
+++ b/walkthroughs/howto-ingress-gateway/infrastructure/ecs-service.yaml
@@ -153,7 +153,7 @@ Resources:
           AssignPublicIp: DISABLED
           SecurityGroups:
             - 'Fn::ImportValue': !Sub "${EnvironmentName}:ECSServiceSecurityGroup"
-          Subnets: 
+          Subnets:
             - 'Fn::ImportValue': !Sub "${EnvironmentName}:PrivateSubnet1"
             - 'Fn::ImportValue': !Sub "${EnvironmentName}:PrivateSubnet2"
       TaskDefinition: { Ref: ColorTellerWhiteTaskDefinition }
@@ -274,7 +274,7 @@ Resources:
           AssignPublicIp: DISABLED
           SecurityGroups:
             - 'Fn::ImportValue': !Sub "${EnvironmentName}:ECSServiceSecurityGroup"
-          Subnets: 
+          Subnets:
             - 'Fn::ImportValue': !Sub "${EnvironmentName}:PrivateSubnet1"
             - 'Fn::ImportValue': !Sub "${EnvironmentName}:PrivateSubnet2"
       TaskDefinition: { Ref: ColorTellerBlackTaskDefinition }
@@ -395,7 +395,7 @@ Resources:
           AssignPublicIp: DISABLED
           SecurityGroups:
             - 'Fn::ImportValue': !Sub "${EnvironmentName}:ECSServiceSecurityGroup"
-          Subnets: 
+          Subnets:
             - 'Fn::ImportValue': !Sub "${EnvironmentName}:PrivateSubnet1"
             - 'Fn::ImportValue': !Sub "${EnvironmentName}:PrivateSubnet2"
       TaskDefinition: { Ref: ColorTellerBlueTaskDefinition }
@@ -516,7 +516,7 @@ Resources:
           AssignPublicIp: DISABLED
           SecurityGroups:
             - 'Fn::ImportValue': !Sub "${EnvironmentName}:ECSServiceSecurityGroup"
-          Subnets: 
+          Subnets:
             - 'Fn::ImportValue': !Sub "${EnvironmentName}:PrivateSubnet1"
             - 'Fn::ImportValue': !Sub "${EnvironmentName}:PrivateSubnet2"
       TaskDefinition: { Ref: ColorTellerRedTaskDefinition }
@@ -598,7 +598,7 @@ Resources:
             - Name: CW_CONFIG_CONTENT
               Value:
                 Fn::Sub:
-                  - '{ \"metrics\": { \"namespace\":\"${MetricNamespace}\", \"metrics_collected\": { \"statsd\": { \"metrics_aggregation_interval\": 0}}}}'
+                  - "{ \"metrics\": { \"namespace\":\"${MetricNamespace}\", \"metrics_collected\": { \"statsd\": { \"metrics_aggregation_interval\": 0}}}}"
                   - MetricNamespace:
                       Fn::Join:
                       - '/'
@@ -633,7 +633,7 @@ Resources:
           AssignPublicIp: DISABLED
           SecurityGroups:
             - 'Fn::ImportValue': !Sub "${EnvironmentName}:ECSServiceSecurityGroup"
-          Subnets: 
+          Subnets:
             - 'Fn::ImportValue': !Sub "${EnvironmentName}:PrivateSubnet1"
             - 'Fn::ImportValue': !Sub "${EnvironmentName}:PrivateSubnet2"
       TaskDefinition: { Ref: ColorGatewayTaskDefinition }
@@ -648,8 +648,8 @@ Resources:
     Properties:
       Scheme: internet-facing
       Subnets:
-        - { 'Fn::ImportValue': !Sub "${EnvironmentName}:PublicSubnet1" }  
-        - { 'Fn::ImportValue': !Sub "${EnvironmentName}:PublicSubnet2" }  
+        - { 'Fn::ImportValue': !Sub "${EnvironmentName}:PublicSubnet1" }
+        - { 'Fn::ImportValue': !Sub "${EnvironmentName}:PublicSubnet2" }
       Type: network
 
   WebTargetGroup:
@@ -671,7 +671,7 @@ Resources:
           Value: 120
       VpcId:
         'Fn::ImportValue': !Sub "${EnvironmentName}:VPC"
-  
+
   PublicLoadBalancerListener:
     Type: AWS::ElasticLoadBalancingV2::Listener
     DependsOn:
@@ -686,7 +686,7 @@ Resources:
       Certificates:
         - CertificateArn: !Sub '${LoadBalancerCertificateArn}'
 
-Outputs: 
+Outputs:
 
   ColorAppEndpoint:
     Description: Public endpoint for Color App service

--- a/walkthroughs/howto-ingress-gateway/src/cloudwatch-agent/deploy.sh
+++ b/walkthroughs/howto-ingress-gateway/src/cloudwatch-agent/deploy.sh
@@ -17,7 +17,7 @@ IMAGE="${ECR_URL}/${CLOUDWATCH_AGENT_IMAGE_NAME}:latest"
 docker build -t $IMAGE $DIR --build-arg GO_PROXY=${GO_PROXY:-"https://proxy.golang.org"}
 
 # ECR login
-AWS_CLI_VERSION=$(aws --version | cut -d/ -f2 | cut -d. -f1)
+AWS_CLI_VERSION=$(aws --version 2>&1 | cut -d/ -f2 | cut -d. -f1)
 
 if [ $AWS_CLI_VERSION -eq 1 ]; then
     $(aws ecr get-login --no-include-email)

--- a/walkthroughs/howto-ingress-gateway/src/colorteller/deploy.sh
+++ b/walkthroughs/howto-ingress-gateway/src/colorteller/deploy.sh
@@ -18,7 +18,7 @@ IMAGE="${ECR_URL}/${COLOR_TELLER_IMAGE_NAME}:latest"
 docker build -t $IMAGE $DIR --build-arg GO_PROXY=${GO_PROXY:-"https://proxy.golang.org"}
 
 # ECR login
-AWS_CLI_VERSION=$(aws --version | cut -d/ -f2 | cut -d. -f1)
+AWS_CLI_VERSION=$(aws --version 2>&1 | cut -d/ -f2 | cut -d. -f1)
 
 if [ $AWS_CLI_VERSION -eq 1 ]; then
     $(aws ecr get-login --no-include-email)


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

This commit fixes minor issues in the ingress-gateway shell script + yaml cfn template:

1. The shell script previously assumed that `aws --version` outputs to
stdout, which is not always true (mine writes to stderr, see https://stackoverflow.com/questions/43280287/why-aws-version-writes-to-stderr).
2. The cfn template previously failed to deploy because of a string
escaping error.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice. ✅
