### PR TITLE
Deploys without exporting environment variables like AWS_PROFILE

### DIFF
--- a/examples/infrastructure/appmesh-mesh.sh
+++ b/examples/infrastructure/appmesh-mesh.sh
@@ -4,8 +4,7 @@ set -ex
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 
-aws --profile "${AWS_PROFILE}" --region "${AWS_DEFAULT_REGION}" \
-    cloudformation deploy \
+aws cloudformation deploy \
     --stack-name "${ENVIRONMENT_NAME}-appmesh-mesh" \
     --capabilities CAPABILITY_IAM \
     --template-file "${DIR}/appmesh-mesh.yaml"  \

--- a/examples/infrastructure/ecs-cluster.sh
+++ b/examples/infrastructure/ecs-cluster.sh
@@ -4,8 +4,7 @@ set -ex
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 
-aws --profile "${AWS_PROFILE}" --region "${AWS_DEFAULT_REGION}" \
-    cloudformation deploy \
+aws cloudformation deploy \
     --stack-name "${ENVIRONMENT_NAME}-ecs-cluster" \
     --capabilities CAPABILITY_IAM \
     --template-file "${DIR}/ecs-cluster.yaml"  \

--- a/examples/infrastructure/eks-cluster.sh
+++ b/examples/infrastructure/eks-cluster.sh
@@ -4,8 +4,7 @@ set -ex
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 
-aws --profile "${AWS_PROFILE}" --region "${AWS_DEFAULT_REGION}" \
-    cloudformation deploy \
+aws cloudformation deploy \
     --stack-name "${ENVIRONMENT_NAME}-eks-cluster" \
     --capabilities CAPABILITY_IAM \
     --template-file "${DIR}/eks-cluster.yaml"  \

--- a/examples/infrastructure/vpc.sh
+++ b/examples/infrastructure/vpc.sh
@@ -4,8 +4,7 @@ set -ex
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 
-aws --profile "${AWS_PROFILE}" --region "${AWS_DEFAULT_REGION}" \
-    cloudformation deploy \
+aws cloudformation deploy \
     --stack-name "${ENVIRONMENT_NAME}-vpc" \
     --capabilities CAPABILITY_IAM \
     --template-file "${DIR}/vpc.yaml" \


### PR DESCRIPTION
*Description of changes:*

In my environment that has no profile under IAM instance roles or some temp credentials I cannot deploy the CloudFormation stacks using the deploy scripts.

I think we don't have to add `profile` and `region` parameters on executing aws cli because `AWS_PROFILE` and `AWS_DEFAULT_REGION` are used by default.

https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.