### PR TITLE
Change ingress LB health check to TCP on listening port

### DIFF
--- a/walkthroughs/howto-ingress-gateway/infrastructure/ecs-service.yaml
+++ b/walkthroughs/howto-ingress-gateway/infrastructure/ecs-service.yaml
@@ -636,7 +636,6 @@ Resources:
           ContainerPort: 9080
           TargetGroupArn: !Ref WebTargetGroup
 
-  # public ALB for color gateway
   PublicLoadBalancer:
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer
     Properties:
@@ -650,10 +649,9 @@ Resources:
     Type: AWS::ElasticLoadBalancingV2::TargetGroup
     Properties:
       HealthCheckIntervalSeconds: 30
-      HealthCheckPath: /server_info
-      HealthCheckPort: 9901
-      HealthCheckProtocol: HTTP
-      HealthCheckTimeoutSeconds: 6
+      HealthCheckPort: 9080
+      HealthCheckProtocol: TCP
+      HealthCheckTimeoutSeconds: 10
       HealthyThresholdCount: 3
       TargetType: ip
       Name: !Sub "${EnvironmentName}-web"


### PR DESCRIPTION
*Description of changes:*

The current ingress gateway example is using a health check from the load balancer to the Envoy administration point. While this health check ensures the Envoy is running, it does not ensure that the relevant listener has bootstrapped and is ready to accept connections. The Envoy /server_info path will always respond 200, even if the Envoy has not bootstrapped it's configuration.

Changing this to a TCP health check on the ingress port for the gateway, which will ensure the listener is ready to accept connections before being considered healthy by the load balancer.

*Testing:*

Re-launched the walkthrough in my environment and asserted that the load balancer considered the ingress gateway healthy.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
