### PR TITLE
Change App Mesh controller deployment name

### DIFF
--- a/walkthroughs/howto-k8s-alb/deploy.sh
+++ b/walkthroughs/howto-k8s-alb/deploy.sh
@@ -55,7 +55,7 @@ check_k8s_virtualservice() {
 check_appmesh_k8s() {
     #check aws-app-mesh-controller version
     if [ "$MANIFEST_VERSION" = "v1beta2" ]; then
-        currentver=$(kubectl get deployment -n appmesh-system appmesh-manager -o json | jq -r ".spec.template.spec.containers[].image" | cut -f2 -d ':'|tail -n1)
+        currentver=$(kubectl get deployment -n appmesh-system appmesh-controller -o json | jq -r ".spec.template.spec.containers[].image" | cut -f2 -d ':'|tail -n1)
         requiredver="v1.0.0"
         check_k8s_virtualrouter
     elif [ "$MANIFEST_VERSION" = "v1beta1" ]; then

--- a/walkthroughs/howto-k8s-cloudmap/deploy.sh
+++ b/walkthroughs/howto-k8s-cloudmap/deploy.sh
@@ -57,7 +57,7 @@ check_virtualnode_v1beta2(){
 check_appmesh_k8s() {
     #check aws-app-mesh-controller version
     if [ "$MANIFEST_VERSION" = "v1beta2" ]; then
-        currentver=$(kubectl get deployment -n appmesh-system appmesh-manager -o json | jq -r ".spec.template.spec.containers[].image" | cut -f2 -d ':'|tail -n1)
+        currentver=$(kubectl get deployment -n appmesh-system appmesh-controller -o json | jq -r ".spec.template.spec.containers[].image" | cut -f2 -d ':'|tail -n1)
         requiredver="v1.0.0"
         check_virtualnode_v1beta2
     elif [ "$MANIFEST_VERSION" = "v1beta1" ]; then

--- a/walkthroughs/howto-k8s-fargate/deploy.sh
+++ b/walkthroughs/howto-k8s-fargate/deploy.sh
@@ -56,7 +56,7 @@ check_k8s_virtualservice() {
 check_appmesh_k8s() {
     #check aws-app-mesh-controller version
     if [ "$MANIFEST_VERSION" = "v1beta2" ]; then
-        currentver=$(kubectl get deployment -n appmesh-system appmesh-manager -o json | jq -r ".spec.template.spec.containers[].image" | cut -f2 -d ':'|tail -n1)
+        currentver=$(kubectl get deployment -n appmesh-system appmesh-controller -o json | jq -r ".spec.template.spec.containers[].image" | cut -f2 -d ':'|tail -n1)
         requiredver="v1.0.0"
         check_k8s_virtualrouter
     elif [ "$MANIFEST_VERSION" = "v1beta1" ]; then

--- a/walkthroughs/howto-k8s-grpc/deploy.sh
+++ b/walkthroughs/howto-k8s-grpc/deploy.sh
@@ -55,7 +55,7 @@ check_k8s_virtualservice() {
 check_appmesh_k8s() {
     #check aws-app-mesh-controller version
     if [ "$MANIFEST_VERSION" = "v1beta2" ]; then
-        currentver=$(kubectl get deployment -n appmesh-system appmesh-manager -o json | jq -r ".spec.template.spec.containers[].image" | cut -f2 -d ':'|tail -n1)
+        currentver=$(kubectl get deployment -n appmesh-system appmesh-controller -o json | jq -r ".spec.template.spec.containers[].image" | cut -f2 -d ':'|tail -n1)
         requiredver="v1.0.0"
         check_k8s_virtualrouter
     elif [ "$MANIFEST_VERSION" = "v1beta1" ]; then

--- a/walkthroughs/howto-k8s-http-headers/deploy.sh
+++ b/walkthroughs/howto-k8s-http-headers/deploy.sh
@@ -55,7 +55,7 @@ check_k8s_virtualservice() {
 check_appmesh_k8s() {
     #check aws-app-mesh-controller version
     if [ "$MANIFEST_VERSION" = "v1beta2" ]; then
-        currentver=$(kubectl get deployment -n appmesh-system appmesh-manager -o json | jq -r ".spec.template.spec.containers[].image" | cut -f2 -d ':'|tail -n1)
+        currentver=$(kubectl get deployment -n appmesh-system appmesh-controller -o json | jq -r ".spec.template.spec.containers[].image" | cut -f2 -d ':'|tail -n1)
         requiredver="v1.0.0"
         check_k8s_virtualrouter
     elif [ "$MANIFEST_VERSION" = "v1beta1" ]; then

--- a/walkthroughs/howto-k8s-http2/deploy.sh
+++ b/walkthroughs/howto-k8s-http2/deploy.sh
@@ -55,7 +55,7 @@ check_k8s_virtualservice() {
 check_appmesh_k8s() {
     #check aws-app-mesh-controller version
     if [ "$MANIFEST_VERSION" = "v1beta2" ]; then
-        currentver=$(kubectl get deployment -n appmesh-system appmesh-manager -o json | jq -r ".spec.template.spec.containers[].image" | cut -f2 -d ':'|tail -n1)
+        currentver=$(kubectl get deployment -n appmesh-system appmesh-controller -o json | jq -r ".spec.template.spec.containers[].image" | cut -f2 -d ':'|tail -n1)
         requiredver="v1.0.0"
         check_k8s_virtualrouter
     elif [ "$MANIFEST_VERSION" = "v1beta1" ]; then

--- a/walkthroughs/howto-k8s-ingress-gateway/README.md
+++ b/walkthroughs/howto-k8s-ingress-gateway/README.md
@@ -5,11 +5,11 @@ In this walkthrough, we'll configure an Ingress Gateway in our existing example 
 A virtual gateway allows resources outside your mesh to communicate to resources that are inside your mesh. The virtual gateway represents an Envoy proxy running in an Amazon ECS, in a Kubernetes service, or on an Amazon EC2 instance. Unlike a virtual node, which represents a proxy running with an application, a virtual gateway represents the proxy deployed by itself.
 
 ## Prerequisites
-This feature is currently only available in App Mesh preview and will work with App Mesh manager [here](https://github.com/aws/eks-charts/tree/master/stable/appmesh-manager)
+This feature is currently only available in App Mesh preview and will work with App Mesh controller [here](https://github.com/aws/eks-charts/tree/master/stable/appmesh-controller)
 
 This example requires [aws-app-mesh-controller-for-k8s](https://github.com/aws/aws-app-mesh-controller-for-k8s) version [>=v1.0.0](https://github.com/aws/aws-app-mesh-controller-for-k8s/blob/master/CHANGELOG.md). Run the following to check the version of controller you are running.
 ```
-$ kubectl get deployment -n appmesh-system appmesh-manager -o json | jq -r ".spec.template.spec.containers[].image" | cut -f2 -d ':'|tail -n1
+$ kubectl get deployment -n appmesh-system appmesh-controller -o json | jq -r ".spec.template.spec.containers[].image" | cut -f2 -d ':'|tail -n1
 ```
 
 ## Setup

--- a/walkthroughs/howto-k8s-ingress-gateway/deploy.sh
+++ b/walkthroughs/howto-k8s-ingress-gateway/deploy.sh
@@ -56,7 +56,7 @@ check_k8s_gatewayroutes() {
 check_appmesh_k8s() {
     #check aws-app-mesh-controller version
     if [ "$MANIFEST_VERSION" = "v1beta2" ]; then
-        currentver=$(kubectl get deployment -n appmesh-system appmesh-manager -o json | jq -r ".spec.template.spec.containers[].image" | cut -f2 -d ':'|tail -n1)
+        currentver=$(kubectl get deployment -n appmesh-system appmesh-controller -o json | jq -r ".spec.template.spec.containers[].image" | cut -f2 -d ':'|tail -n1)
         requiredver="v1.0.0"
         check_k8s_virtualgateway
         check_k8s_gatewayroutes

--- a/walkthroughs/howto-k8s-retry-policy/deploy.sh
+++ b/walkthroughs/howto-k8s-retry-policy/deploy.sh
@@ -55,7 +55,7 @@ check_k8s_virtualservice() {
 check_appmesh_k8s() {
     #check aws-app-mesh-controller version
     if [ "$MANIFEST_VERSION" = "v1beta2" ]; then
-        currentver=$(kubectl get deployment -n appmesh-system appmesh-manager -o json | jq -r ".spec.template.spec.containers[].image" | cut -f2 -d ':'|tail -n1)
+        currentver=$(kubectl get deployment -n appmesh-system appmesh-controller -o json | jq -r ".spec.template.spec.containers[].image" | cut -f2 -d ':'|tail -n1)
         requiredver="v1.0.0"
         check_k8s_virtualrouter
     elif [ "$MANIFEST_VERSION" = "v1beta1" ]; then


### PR DESCRIPTION
*Description of changes:*
Deployment name for App Mesh controller will be appmesh-controller moving forward: https://github.com/aws/eks-charts/pull/173

This PR changes the name from appmesh-manager to appmesh-controller in k8s examples


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
