### PR TITLE
App Mesh k8s ingress README and preview instructions update

### DIFF
--- a/walkthroughs/howto-k8s-ingress-gateway/deploy.sh
+++ b/walkthroughs/howto-k8s-ingress-gateway/deploy.sh
@@ -21,7 +21,6 @@ DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
 PROJECT_NAME="howto-k8s-ingress-gateway"
 APP_NAMESPACE=${PROJECT_NAME}
 MESH_NAME=${PROJECT_NAME}
-APPMESH_PREVIEW="enabled"
 
 ECR_URL="${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
 ECR_IMAGE_PREFIX="${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/${PROJECT_NAME}"

--- a/walkthroughs/howto-k8s-ingress-gateway/v1beta2/manifest.yaml.template
+++ b/walkthroughs/howto-k8s-ingress-gateway/v1beta2/manifest.yaml.template
@@ -380,8 +380,6 @@ spec:
       labels:
         app: color
         version: green
-      annotations:
-        appmesh.k8s.aws/preview: ${APPMESH_PREVIEW}
     spec:
       containers:
         - name: app
@@ -421,8 +419,6 @@ spec:
       labels:
         app: color
         version: blue
-      annotations:
-        appmesh.k8s.aws/preview: ${APPMESH_PREVIEW}
     spec:
       containers:
         - name: app
@@ -462,8 +458,6 @@ spec:
       labels:
         app: color
         version: red
-      annotations:
-        appmesh.k8s.aws/preview: ${APPMESH_PREVIEW}
     spec:
       containers:
         - name: app
@@ -503,8 +497,6 @@ spec:
       labels:
         app: color
         version: yellow
-      annotations:
-        appmesh.k8s.aws/preview: ${APPMESH_PREVIEW}
     spec:
       containers:
         - name: app
@@ -544,8 +536,6 @@ spec:
       labels:
         app: color
         version: white
-      annotations:
-        appmesh.k8s.aws/preview: ${APPMESH_PREVIEW}
     spec:
       containers:
         - name: app
@@ -606,8 +596,6 @@ spec:
     metadata:
       labels:
         app: ingress-gw
-      annotations:
-        appmesh.k8s.aws/preview: ${APPMESH_PREVIEW}
     spec:
       containers:
         - name: envoy


### PR DESCRIPTION
*Description of changes:*
- Latest preview Helm chart and controller is available [here](https://github.com/aws/eks-charts/tree/preview/stable/appmesh-controller)
- The preview Helm chart enabled data plane preview flag so we don't need to explicitly specify it in the example anymore
- Added instructions on how to setup AWS CLI for preview channel and use it


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
