### PR TITLE
Add color attributes to k8s cloudmap walkthrough nodes

### DIFF
--- a/walkthroughs/howto-k8s-cloudmap/v1beta2/manifest.yaml.template
+++ b/walkthroughs/howto-k8s-cloudmap/v1beta2/manifest.yaml.template
@@ -56,6 +56,9 @@ spec:
     awsCloudMap:
       namespaceName: ${CLOUDMAP_NAMESPACE}
       serviceName: colorapp
+      attributes:
+      - key: color
+        value: blue
 ---
 apiVersion: appmesh.k8s.aws/v1beta2
 kind: VirtualNode
@@ -75,6 +78,9 @@ spec:
     awsCloudMap:
       namespaceName: ${CLOUDMAP_NAMESPACE}
       serviceName: colorapp
+      attributes:
+      - key: color
+        value: red
 ---
 apiVersion: appmesh.k8s.aws/v1beta2
 kind: VirtualService


### PR DESCRIPTION
*Issue #, if available:* aws/aws-app-mesh-roadmap#225

*Description of changes:*

The current walkthrough for Cloud Map on Kubernetes will not work because the red and blue virtual nodes share the same service discovery settings. This PR adds color attributes to them so they can be distinguished by the `front` service.

Aside: it appears the legacy controller [doesn't support attributes](https://github.com/aws/aws-app-mesh-controller-for-k8s/blob/legacy-controller/deploy/all.yaml#L186-L192). How did this demo work on that controller version?

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
