### PR TITLE
fix binary data handling for acm invocations with aws cli v2

### DIFF
--- a/walkthroughs/howto-ingress-gateway/README.md
+++ b/walkthroughs/howto-ingress-gateway/README.md
@@ -155,7 +155,14 @@ ROOT_CA_CSR=`aws acm-pca get-certificate-authority-csr \
     --certificate-authority-arn ${ROOT_CA_ARN} \
     --query Csr --output text`
 ```
-Sign the CSR using itself as the issuer:
+Sign the CSR using itself as the issuer.
+
+Note that if you are using AWS CLI version 2, you will need to pass the CSR data through encoding prior to invoking the 'issue-certificate' command.
+
+```bash
+AWS_CLI_VERSION=$(aws --version 2>&1 | cut -d/ -f2 | cut -d. -f1)
+[[ ${AWS_CLI_VERSION} -gt 1 ]] && ROOT_CA_CSR="$(echo ${ROOT_CA_CSR} | base64)"
+```
 
 ```bash
 ROOT_CA_CERT_ARN=`aws acm-pca issue-certificate \
@@ -173,7 +180,17 @@ ROOT_CA_CERT=`aws acm-pca get-certificate \
     --certificate-arn ${ROOT_CA_CERT_ARN} \
     --certificate-authority-arn ${ROOT_CA_ARN} \
     --query Certificate --output text`
+```
 
+Note again with AWS CLI version 2, you will need to pass the certificate data through encoding.
+
+```bash
+[[ ${AWS_CLI_VERSION} -gt 1 ]] && ROOT_CA_CERT="$(echo ${ROOT_CA_CERT} | base64)"
+```
+
+Import the certificate:
+
+```bash
 aws acm-pca import-certificate-authority-certificate \
     --certificate-authority-arn $ROOT_CA_ARN \
     --certificate "${ROOT_CA_CERT}"

--- a/walkthroughs/tls-with-acm/README.md
+++ b/walkthroughs/tls-with-acm/README.md
@@ -98,7 +98,14 @@ ROOT_CA_CSR=`aws acm-pca get-certificate-authority-csr \
     --query Csr --output text`
 ```
 
-Sign the CSR using itself as the issuer:
+Sign the CSR using itself as the issuer.
+
+Note that if you are using AWS CLI version 2, you will need to pass the CSR data through encoding prior to invoking the 'issue-certificate' command.
+
+```bash
+AWS_CLI_VERSION=$(aws --version 2>&1 | cut -d/ -f2 | cut -d. -f1)
+[[ ${AWS_CLI_VERSION} -gt 1 ]] && ROOT_CA_CSR="$(echo ${ROOT_CA_CSR} | base64)"
+```
 
 ```bash
 ROOT_CA_CERT_ARN=`aws acm-pca issue-certificate \
@@ -117,7 +124,17 @@ ROOT_CA_CERT=`aws acm-pca get-certificate \
     --certificate-arn ${ROOT_CA_CERT_ARN} \
     --certificate-authority-arn ${ROOT_CA_ARN} \
     --query Certificate --output text`
+```
 
+Note again with AWS CLI version 2, you will need to pass the certificate data through encoding.
+
+```bash
+[[ ${AWS_CLI_VERSION} -gt 1 ]] && ROOT_CA_CERT="$(echo ${ROOT_CA_CERT} | base64)"
+```
+
+Import the certificate:
+
+```bash
 aws acm-pca import-certificate-authority-certificate \
     --certificate-authority-arn $ROOT_CA_ARN \
     --certificate "${ROOT_CA_CERT}"


### PR DESCRIPTION
*Issue #, if available:*  addresses issue #318 

*Description of changes:*  Add a cli version check and, if necessary, pass data through base64 encoding. This was needed in two walkthroughs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
