### PR TITLE
Fix to CF output for ecs-service in virtual-gateway how to walkthrough. TLS is enabled at the onset from the NLB.

### DIFF
--- a/walkthroughs/howto-ingress-gateway/infrastructure/ecs-service.yaml
+++ b/walkthroughs/howto-ingress-gateway/infrastructure/ecs-service.yaml
@@ -673,4 +673,4 @@ Outputs:
 
   ColorAppEndpoint:
     Description: Public endpoint for Color App service
-    Value: !Join ['', ['http://', !GetAtt 'PublicLoadBalancer.DNSName']]
+    Value: !Join ['', ['https://', !GetAtt 'PublicLoadBalancer.DNSName']]


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This update is related to the how-to for virtual-gateway ingress found here (walkthroughs/howto-ingress-gateway). The output from the CF for the ecs service provides an http endpoint, which is not reachable as we enable TLS at the load balancer. Simply modifying output of ecs-service.yaml in CF to https.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
