### PR TITLE
Fix typo in the document

### DIFF
--- a/walkthroughs/howto-cross-account/README.md
+++ b/walkthroughs/howto-cross-account/README.md
@@ -82,7 +82,7 @@ These backends will be configured in distinct accounts and made accessible throu
         ```
         export KEY_PAIR=...
         ```
-3. Source the `env.vars` file using `source env.vars`
+3. Source the `vars.env` file using `source vars.env`
 4. Setup base cloudformation stack by running
     ```
     ./deploy.sh


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
fix incorrect env files name ```env.vars``` to ```vars.env```.
