### PR TITLE
Update deploy.sh to work with AWS CLI v2

### DIFF
--- a/walkthroughs/howto-k8s-http2/deploy.sh
+++ b/walkthroughs/howto-k8s-http2/deploy.sh
@@ -89,7 +89,7 @@ deploy_images() {
 }
 
 deploy_cloudmap_ns() {
-    nsId=($(aws servicediscovery list-namespaces |
+    nsId=($(aws servicediscovery list-namespaces --output json |
         jq -r ".Namespaces[] | select(.Name | contains(\"${CLOUDMAP_NAMESPACE}\")) | .Id"))
 
     if [ -z "${nsId}" ]; then


### PR DESCRIPTION
The default output of AWS CLI v2 is no longer JSON. Added the flag to force a JSON output that is then used by jq

*Issue #, if available:*

*Description of changes:*
Changed the howto-k8s-http2 walkthrough only as it is the first workload to deploy. The default output of AWS CLI v2 is no longer JSON. Added the flag to force a JSON output that is then used by jq.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
