### PR TITLE
Add docker pre-req to the walkthroughs

### DIFF
--- a/walkthroughs/howto-alb/README.md
+++ b/walkthroughs/howto-alb/README.md
@@ -11,6 +11,9 @@ V1 is registered as a virtual-node with service-discovery set to DNS (ALB's DNS)
 ### Frontend
 Frontend app is ECS service that runs in private subnet behind internet-facing ALB. Frontend is registered with App Mesh as virtual-node with backends set to Backend's virtual-service. Frontend is deployed with Envoy sidecar that communicates with Backend.
 
+## Prerequisites
+1. Install Docker. It is needed to build the demo application images
+
 ## Setup
 
 1. Clone this repository and navigate to the walkthrough/howto-alb folder, all commands will be ran from this location

--- a/walkthroughs/howto-alb/README.md
+++ b/walkthroughs/howto-alb/README.md
@@ -12,7 +12,7 @@ V1 is registered as a virtual-node with service-discovery set to DNS (ALB's DNS)
 Frontend app is ECS service that runs in private subnet behind internet-facing ALB. Frontend is registered with App Mesh as virtual-node with backends set to Backend's virtual-service. Frontend is deployed with Envoy sidecar that communicates with Backend.
 
 ## Prerequisites
-1. Install Docker. It is needed to build the demo application images
+1. Install Docker. It is needed to build the demo application images.
 
 ## Setup
 

--- a/walkthroughs/howto-circuit-breakers/README.md
+++ b/walkthroughs/howto-circuit-breakers/README.md
@@ -22,7 +22,7 @@ We go through the exercise of setting up connection pool settings at the Virtual
     This command creates an Amazon EC2 Key Pair with name `color-app` and saves the private key at `~/.ssh/color-app.pem`.
 
 4. Additionally, this walkthrough makes use of the unix command line utility `jq`. If you don't already have it, you can install it from [here](https://stedolan.github.io/jq/).
-5. Install Docker. It is needed to build the demo application images
+5. Install Docker. It is needed to build the demo application images.
 
 ## Step 2: Set Environment Variables
 We need to set a few environment variables before provisioning the infrastructure.

--- a/walkthroughs/howto-circuit-breakers/README.md
+++ b/walkthroughs/howto-circuit-breakers/README.md
@@ -21,7 +21,8 @@ We go through the exercise of setting up connection pool settings at the Virtual
 
     This command creates an Amazon EC2 Key Pair with name `color-app` and saves the private key at `~/.ssh/color-app.pem`.
 
-4. Additionally, this walkthrough makes use of the unix command line utility `jq`. If you don't already have it, you can install it from [here](https://stedolan.github.io/jq/). 
+4. Additionally, this walkthrough makes use of the unix command line utility `jq`. If you don't already have it, you can install it from [here](https://stedolan.github.io/jq/).
+5. Install Docker. It is needed to build the demo application images
 
 ## Step 2: Set Environment Variables
 We need to set a few environment variables before provisioning the infrastructure.

--- a/walkthroughs/howto-cross-account/README.md
+++ b/walkthroughs/howto-cross-account/README.md
@@ -18,7 +18,7 @@ The two backends are "Hello World!" applications that each listen on port 80.
 These backends will be configured in distinct accounts and made accessible through the gateway. We will manipulate routes that show that we are able to migrate traffic from one destination to another using the App Mesh APIs.
 
 ## Prerequisites
-1. Install Docker. It is needed to build the demo application images
+1. Install Docker. It is needed to build the demo application images.
 
 ## Setup
 

--- a/walkthroughs/howto-cross-account/README.md
+++ b/walkthroughs/howto-cross-account/README.md
@@ -17,6 +17,9 @@ The two backends are "Hello World!" applications that each listen on port 80.
 
 These backends will be configured in distinct accounts and made accessible through the gateway. We will manipulate routes that show that we are able to migrate traffic from one destination to another using the App Mesh APIs.
 
+## Prerequisites
+1. Install Docker. It is needed to build the demo application images
+
 ## Setup
 
 1. Clone this repository and navigate to the walkthroughs/howto-cross-account folder, all commands will be ran from this location.

--- a/walkthroughs/howto-ecs-basics/README.md
+++ b/walkthroughs/howto-ecs-basics/README.md
@@ -5,7 +5,7 @@ This tutorial provides a walkthrough of the basics of App Mesh service. This int
 2. Adopt App Mesh for service to service communication via Envoy proxy. This will build on Cloud Map service discovery integration.
 
 ## Prerequisites
-1. Install Docker. It is needed to build the demo application images
+1. Install Docker. It is needed to build the demo application images.
 
 ## Bootstrap
 

--- a/walkthroughs/howto-ecs-basics/README.md
+++ b/walkthroughs/howto-ecs-basics/README.md
@@ -4,6 +4,9 @@ This tutorial provides a walkthrough of the basics of App Mesh service. This int
 1. Migrate an existing backend service sitting behind an internal ALB to Cloud Map service discovery. Along the way you will learn about Cloud Map's HttpNamespace, and how ECS service integrates with Cloud Map service discovery.
 2. Adopt App Mesh for service to service communication via Envoy proxy. This will build on Cloud Map service discovery integration.
 
+## Prerequisites
+1. Install Docker. It is needed to build the demo application images
+
 ## Bootstrap
 
 1. Clone this repository and navigate to the walkthrough/howto-ecs-basics folder, all commands will be ran from this location

--- a/walkthroughs/howto-grpc-ingress-gateway/README.md
+++ b/walkthroughs/howto-grpc-ingress-gateway/README.md
@@ -12,6 +12,9 @@ The Color Server is a gRPC server that implements `SetColor` and `GetColor` meth
 
 The front-end is Virtual Gateway that maintains a persistent gRPC connection to the Color Server. The Virtual Gateway will be connected to an internet-facing NLB. It forwards the gRPC connections to the same methods in [color.ColorService](./color.proto).
 
+## Prerequisites
+1. Install Docker. It is needed to build the demo application images
+
 ## Setup
 
 1. Clone this repository and navigate to the walkthroughs/howto-grpc-ingress-gateway folder, all commands will be ran from this location.

--- a/walkthroughs/howto-grpc-ingress-gateway/README.md
+++ b/walkthroughs/howto-grpc-ingress-gateway/README.md
@@ -13,7 +13,7 @@ The Color Server is a gRPC server that implements `SetColor` and `GetColor` meth
 The front-end is Virtual Gateway that maintains a persistent gRPC connection to the Color Server. The Virtual Gateway will be connected to an internet-facing NLB. It forwards the gRPC connections to the same methods in [color.ColorService](./color.proto).
 
 ## Prerequisites
-1. Install Docker. It is needed to build the demo application images
+1. Install Docker. It is needed to build the demo application images.
 
 ## Setup
 

--- a/walkthroughs/howto-grpc/README.md
+++ b/walkthroughs/howto-grpc/README.md
@@ -12,6 +12,9 @@ The Color Server is a gRPC server that implements [color.ColorService](./color.p
 
 The Color Client is a HTTP/1.1 front-end webserver that maintains a persistent gRPC connection to the Color Server. The HTTP/1.1 webserver will be connected to an internet-facing ALB. It forwards requests to `/getColor` and `/setColor` to the same methods in [color.ColorService](./color.proto). Initially, the Envoy sidecar for the Color Client will be configured to only route the `GetColor` gRPC method, but we will update the route to forward all methods to the Color Server.
 
+## Prerequisites
+1. Install Docker. It is needed to build the demo application images
+
 ## Setup
 
 1. Clone this repository and navigate to the walkthroughs/howto-grpc folder, all commands will be ran from this location.

--- a/walkthroughs/howto-grpc/README.md
+++ b/walkthroughs/howto-grpc/README.md
@@ -13,7 +13,7 @@ The Color Server is a gRPC server that implements [color.ColorService](./color.p
 The Color Client is a HTTP/1.1 front-end webserver that maintains a persistent gRPC connection to the Color Server. The HTTP/1.1 webserver will be connected to an internet-facing ALB. It forwards requests to `/getColor` and `/setColor` to the same methods in [color.ColorService](./color.proto). Initially, the Envoy sidecar for the Color Client will be configured to only route the `GetColor` gRPC method, but we will update the route to forward all methods to the Color Server.
 
 ## Prerequisites
-1. Install Docker. It is needed to build the demo application images
+1. Install Docker. It is needed to build the demo application images.
 
 ## Setup
 

--- a/walkthroughs/howto-http-headers/README.md
+++ b/walkthroughs/howto-http-headers/README.md
@@ -25,6 +25,9 @@ This mesh has the following resources:
   1. `color-route-white`: A route with a header match rule to match weather the pseudo header name `:method` has a value that matches `GET`.
   1. `color-route-black`: A route with a header match rule to match weather the pseudo header name `:scheme` has a value that matches the prefix `https`.
 
+## Prerequisites
+1. Install Docker. It is needed to build the demo application images
+
 ## Setup
 
 1. Your account id:

--- a/walkthroughs/howto-http-headers/README.md
+++ b/walkthroughs/howto-http-headers/README.md
@@ -26,7 +26,7 @@ This mesh has the following resources:
   1. `color-route-black`: A route with a header match rule to match weather the pseudo header name `:scheme` has a value that matches the prefix `https`.
 
 ## Prerequisites
-1. Install Docker. It is needed to build the demo application images
+1. Install Docker. It is needed to build the demo application images.
 
 ## Setup
 

--- a/walkthroughs/howto-http-retries/README.md
+++ b/walkthroughs/howto-http-retries/README.md
@@ -3,7 +3,7 @@
 This example shows how we can set retry duration and attempts within route configurations. In this mesh we have a frontend service and a color service. When a request is made, the frontend service will create a header to denote the current time and send that request to the color service. The color service will respond with a 503 if the time of the original request (passed through the header) and the current time is less than 1 second. Initially without retry in place this error will be thrown consistently. After we introduce retries, we will begin to see the time of the original request and the current time will eventually be greater than 1 second (depending on the retry policy configuration you want to set but the example configuration will work once the route is updated during the walkthrough). At this point the color service will return a 200 and send back the color. 
 
 ## Prerequisites
-1. Install Docker. It is needed to build the demo application images
+1. Install Docker. It is needed to build the demo application images.
 
 ## Setup
 

--- a/walkthroughs/howto-http-retries/README.md
+++ b/walkthroughs/howto-http-retries/README.md
@@ -2,6 +2,9 @@
 
 This example shows how we can set retry duration and attempts within route configurations. In this mesh we have a frontend service and a color service. When a request is made, the frontend service will create a header to denote the current time and send that request to the color service. The color service will respond with a 503 if the time of the original request (passed through the header) and the current time is less than 1 second. Initially without retry in place this error will be thrown consistently. After we introduce retries, we will begin to see the time of the original request and the current time will eventually be greater than 1 second (depending on the retry policy configuration you want to set but the example configuration will work once the route is updated during the walkthrough). At this point the color service will return a 200 and send back the color. 
 
+## Prerequisites
+1. Install Docker. It is needed to build the demo application images
+
 ## Setup
 
 1. Clone this repository and navigate to the walkthrough/http-retry-policy folder, all commands will be ran from this location

--- a/walkthroughs/howto-http2/README.md
+++ b/walkthroughs/howto-http2/README.md
@@ -13,7 +13,7 @@ The Color Server is a simple go HTTP2 server returns a color. In this example, w
 The Color Client is a HTTP/1.1 front-end webserver that communicates to the Color Server over HTTP2. The HTTP/1.1 webserver will be connected to an internet-facing ALB. It forwards requests for `/color` to a Color Server backend. Initially, the Envoy sidecar for the Color Client will be configured to only route the `red`-type virtual-nodes, but we will update the route to load-balance across all three types.
 
 ## Prerequisites
-1. Install Docker. It is needed to build the demo application images
+1. Install Docker. It is needed to build the demo application images.
 
 ## Setup
 

--- a/walkthroughs/howto-http2/README.md
+++ b/walkthroughs/howto-http2/README.md
@@ -12,6 +12,9 @@ The Color Server is a simple go HTTP2 server returns a color. In this example, w
 
 The Color Client is a HTTP/1.1 front-end webserver that communicates to the Color Server over HTTP2. The HTTP/1.1 webserver will be connected to an internet-facing ALB. It forwards requests for `/color` to a Color Server backend. Initially, the Envoy sidecar for the Color Client will be configured to only route the `red`-type virtual-nodes, but we will update the route to load-balance across all three types.
 
+## Prerequisites
+1. Install Docker. It is needed to build the demo application images
+
 ## Setup
 
 1. Clone this repository and navigate to the walkthroughs/howto-http2 folder, all commands will be ran from this location.

--- a/walkthroughs/howto-ingress-gateway/README.md
+++ b/walkthroughs/howto-ingress-gateway/README.md
@@ -89,7 +89,7 @@ Internet --> (terminate TLS) NLB (originate TLS) --> (terminate TLS) Gateway (or
 
 ## Step 1: Prerequisites
 
-You'll need a keypair stored in AWS to access a bastion host. You can create a keypair using the command below if you don't have one. See [Amazon EC2 Key Pairs](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html).
+1. You'll need a keypair stored in AWS to access a bastion host. You can create a keypair using the command below if you don't have one. See [Amazon EC2 Key Pairs](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html).
 
 ```bash
 aws ec2 create-key-pair --key-name color-app | jq -r .KeyMaterial > ~/.ssh/color-app.pem
@@ -99,7 +99,9 @@ chmod go-r ~/.ssh/color-app.pem
 This command creates an Amazon EC2 Key Pair with name `color-app` and saves the private key at
 `~/.ssh/color-app.pem`.
 
-Additionally, this walkthrough makes use of the unix command line utility `jq`. If you don't already have it, you can install it from [here](https://stedolan.github.io/jq/).
+2. Additionally, this walkthrough makes use of the unix command line utility `jq`. If you don't already have it, you can install it from [here](https://stedolan.github.io/jq/).
+
+3. Install Docker. It is needed to build the demo application images
 
 ## Step 2: Set Environment Variables
 We need to set a few environment variables before provisioning the

--- a/walkthroughs/howto-ingress-gateway/README.md
+++ b/walkthroughs/howto-ingress-gateway/README.md
@@ -101,7 +101,7 @@ This command creates an Amazon EC2 Key Pair with name `color-app` and saves the 
 
 2. Additionally, this walkthrough makes use of the unix command line utility `jq`. If you don't already have it, you can install it from [here](https://stedolan.github.io/jq/).
 
-3. Install Docker. It is needed to build the demo application images
+3. Install Docker. It is needed to build the demo application images.
 
 ## Step 2: Set Environment Variables
 We need to set a few environment variables before provisioning the

--- a/walkthroughs/howto-k8s-alb/README.md
+++ b/walkthroughs/howto-k8s-alb/README.md
@@ -6,7 +6,7 @@ This example shows how to use [ALB Ingress Controller](https://github.com/kubern
 ## Prerequisites
 - [Walkthrough: App Mesh with EKS](../eks/)
 - [Walkthrough: ALB Ingress Controller](https://kubernetes-sigs.github.io/aws-alb-ingress-controller/guide/walkthrough/echoserver/)
-- Install Docker. It is needed to build the demo application images
+- Install Docker. It is needed to build the demo application images.
 
 Note: Only [deploy the ALB Ingress Controller](https://kubernetes-sigs.github.io/aws-alb-ingress-controller/guide/walkthrough/echoserver/#deploy-the-alb-ingress-controller) and rest this example service will replace the echoserver in the ALB Ingress Controller link provider
 

--- a/walkthroughs/howto-k8s-alb/README.md
+++ b/walkthroughs/howto-k8s-alb/README.md
@@ -6,6 +6,7 @@ This example shows how to use [ALB Ingress Controller](https://github.com/kubern
 ## Prerequisites
 - [Walkthrough: App Mesh with EKS](../eks/)
 - [Walkthrough: ALB Ingress Controller](https://kubernetes-sigs.github.io/aws-alb-ingress-controller/guide/walkthrough/echoserver/)
+- Install Docker. It is needed to build the demo application images
 
 Note: Only [deploy the ALB Ingress Controller](https://kubernetes-sigs.github.io/aws-alb-ingress-controller/guide/walkthrough/echoserver/#deploy-the-alb-ingress-controller) and rest this example service will replace the echoserver in the ALB Ingress Controller link provider
 

--- a/walkthroughs/howto-k8s-cloudmap/README.md
+++ b/walkthroughs/howto-k8s-cloudmap/README.md
@@ -12,15 +12,16 @@ Additionally a colorapp virtual-service is defined that routes traffic to blue a
 Front app acts as a gateway that makes remote calls to colorapp. Front app has single deployment with pods registered with the mesh as _front_ virtual-node. This virtual-node uses colorapp virtual-service as backend. This configures Envoy injected into front pod to use App Mesh's EDS to discover colorapp endpoints.
 
 ## Prerequisites
-[Walkthrough: App Mesh with EKS](../eks/)
+1. [Walkthrough: App Mesh with EKS](../eks/)
 
-v1beta2 example manifest requires [aws-app-mesh-controller-for-k8s](https://github.com/aws/aws-app-mesh-controller-for-k8s) version [>=v1.0.0](https://github.com/aws/aws-app-mesh-controller-for-k8s/releases/tag/v1.0.0). Run the following to check the version of controller you are running.
+2. v1beta2 example manifest requires [aws-app-mesh-controller-for-k8s](https://github.com/aws/aws-app-mesh-controller-for-k8s) version [>=v1.0.0](https://github.com/aws/aws-app-mesh-controller-for-k8s/releases/tag/v1.0.0). Run the following to check the version of controller you are running.
 ```
 $ kubectl get deployment -n appmesh-system appmesh-controller -o json | jq -r ".spec.template.spec.containers[].image" | cut -f2 -d ':'|tail -n1
 ```
 
 You can use v1beta1 example manifest with [aws-app-mesh-controller-for-k8s](https://github.com/aws/aws-app-mesh-controller-for-k8s) version [=v0.3.0](https://github.com/aws/aws-app-mesh-controller-for-k8s/blob/legacy-controller/CHANGELOG.md)
 
+3. Install Docker. It is needed to build the demo application images
 
 ## Setup
 

--- a/walkthroughs/howto-k8s-cloudmap/README.md
+++ b/walkthroughs/howto-k8s-cloudmap/README.md
@@ -21,7 +21,7 @@ $ kubectl get deployment -n appmesh-system appmesh-controller -o json | jq -r ".
 
 You can use v1beta1 example manifest with [aws-app-mesh-controller-for-k8s](https://github.com/aws/aws-app-mesh-controller-for-k8s) version [=v0.3.0](https://github.com/aws/aws-app-mesh-controller-for-k8s/blob/legacy-controller/CHANGELOG.md)
 
-3. Install Docker. It is needed to build the demo application images
+3. Install Docker. It is needed to build the demo application images.
 
 ## Setup
 

--- a/walkthroughs/howto-k8s-connection-pools/README.md
+++ b/walkthroughs/howto-k8s-connection-pools/README.md
@@ -16,7 +16,7 @@ kubectl get deployment -n appmesh-system appmesh-controller -o json | jq -r ".sp
 v1.2.0
 ```
 
-3. Install Docker. `deploy.sh` script builds the demo application images using Docker CLI.
+3. Install Docker. It is needed to build the demo application images
 
 
 ## Step 1: Setup environment

--- a/walkthroughs/howto-k8s-connection-pools/README.md
+++ b/walkthroughs/howto-k8s-connection-pools/README.md
@@ -16,7 +16,7 @@ kubectl get deployment -n appmesh-system appmesh-controller -o json | jq -r ".sp
 v1.2.0
 ```
 
-3. Install Docker. It is needed to build the demo application images
+3. Install Docker. It is needed to build the demo application images.
 
 
 ## Step 1: Setup environment

--- a/walkthroughs/howto-k8s-cross-cluster/README.md
+++ b/walkthroughs/howto-k8s-cross-cluster/README.md
@@ -39,7 +39,7 @@ In order to successfully carry out the base deployment:
 * Make sure to have jq installed (https://stedolan.github.io/jq/download/).
 * Make sure to have aws-iam-authenticator installed (https://github.com/kubernetes-sigs/aws-iam-authenticator), required for eksctl
 * Install eksctl (https://eksctl.io/), for example, on macOS with brew tap weaveworks/tap and brew install weaveworks/tap/eksctl, and make sure it's on at least on version 0.23.0.
-* Install Docker. It is needed to build the demo application images 
+* Install Docker. It is needed to build the demo application images.
 
 v1beta2 example manifest requires [aws-app-mesh-controller-for-k8s](https://github.com/aws/aws-app-mesh-controller-for-k8s) version [>=v1.0.0](https://github.com/aws/aws-app-mesh-controller-for-k8s/releases/tag/v1.0.0). Run the following to check the version of controller you are running.
 ```

--- a/walkthroughs/howto-k8s-cross-cluster/README.md
+++ b/walkthroughs/howto-k8s-cross-cluster/README.md
@@ -38,7 +38,8 @@ In order to successfully carry out the base deployment:
 * Make sure to have kubectl installed (https://kubernetes.io/docs/tasks/tools/install-kubectl/), at least version 1.11 or above.
 * Make sure to have jq installed (https://stedolan.github.io/jq/download/).
 * Make sure to have aws-iam-authenticator installed (https://github.com/kubernetes-sigs/aws-iam-authenticator), required for eksctl
-* Install eksctl (https://eksctl.io/), for example, on macOS with brew tap weaveworks/tap and brew install weaveworks/tap/eksctl, and make sure it's on at least on version 0.23.0. 
+* Install eksctl (https://eksctl.io/), for example, on macOS with brew tap weaveworks/tap and brew install weaveworks/tap/eksctl, and make sure it's on at least on version 0.23.0.
+* Install Docker. It is needed to build the demo application images 
 
 v1beta2 example manifest requires [aws-app-mesh-controller-for-k8s](https://github.com/aws/aws-app-mesh-controller-for-k8s) version [>=v1.0.0](https://github.com/aws/aws-app-mesh-controller-for-k8s/releases/tag/v1.0.0). Run the following to check the version of controller you are running.
 ```

--- a/walkthroughs/howto-k8s-egress/README.md
+++ b/walkthroughs/howto-k8s-egress/README.md
@@ -7,12 +7,14 @@ The example will create two Kubernetes namespaces: `howto-k8s-egress` and `mesh-
   * by using Mesh `DROP_ALL` egress filter with blue service exposed via a virtual node (to make it selectively accessible)
 
 ## Prerequisites
-[Walkthrough: App Mesh with EKS](../eks/)
+1. [Walkthrough: App Mesh with EKS](../eks/)
 
-The manifest in this walkthrough requires [aws-app-mesh-controller-for-k8s](https://github.com/aws/aws-app-mesh-controller-for-k8s) version [>=v1.0.0](https://github.com/aws/aws-app-mesh-controller-for-k8s/releases/tag/v1.0.0). Run the following to check the version of controller you are running.
+2. The manifest in this walkthrough requires [aws-app-mesh-controller-for-k8s](https://github.com/aws/aws-app-mesh-controller-for-k8s) version [>=v1.0.0](https://github.com/aws/aws-app-mesh-controller-for-k8s/releases/tag/v1.0.0). Run the following to check the version of controller you are running.
 ```
 $ kubectl get deployment -n appmesh-system appmesh-controller -o json | jq -r ".spec.template.spec.containers[].image" | cut -f2 -d ':'|tail -n1
 ```
+
+3. Install Docker. `deploy.sh` script builds the demo application images using Docker CLI.
 
 ## Setup
 1. Clone this repository and navigate to the walkthrough/howto-k8s-egress folder, all commands will be ran from this location

--- a/walkthroughs/howto-k8s-fargate/README.md
+++ b/walkthroughs/howto-k8s-fargate/README.md
@@ -7,7 +7,7 @@ $ kubectl get deployment -n appmesh-system appmesh-controller -o json | jq -r ".
 
 You can use v1beta1 example manifest with [aws-app-mesh-controller-for-k8s](https://github.com/aws/aws-app-mesh-controller-for-k8s) version [=v0.3.0](https://github.com/aws/aws-app-mesh-controller-for-k8s/blob/legacy-controller/CHANGELOG.md)
 
-2. Install Docker. It is needed to build the demo application images
+2. Install Docker. It is needed to build the demo application images.
 
 ## Setup environment
 - Setup following environment variables

--- a/walkthroughs/howto-k8s-fargate/README.md
+++ b/walkthroughs/howto-k8s-fargate/README.md
@@ -1,12 +1,15 @@
 ## Prerequisites
 
-v1beta2 example manifest requires [aws-app-mesh-controller-for-k8s](https://github.com/aws/aws-app-mesh-controller-for-k8s) version [>=v1.0.0](https://github.com/aws/aws-app-mesh-controller-for-k8s/releases/tag/v1.0.0). Run the following to check the version of controller you are running.
+1. v1beta2 example manifest requires [aws-app-mesh-controller-for-k8s](https://github.com/aws/aws-app-mesh-controller-for-k8s) version [>=v1.0.0](https://github.com/aws/aws-app-mesh-controller-for-k8s/releases/tag/v1.0.0). Run the following to check the version of controller you are running.
 ```
 $ kubectl get deployment -n appmesh-system appmesh-controller -o json | jq -r ".spec.template.spec.containers[].image" | cut -f2 -d ':'|tail -n1
 ```
 
 You can use v1beta1 example manifest with [aws-app-mesh-controller-for-k8s](https://github.com/aws/aws-app-mesh-controller-for-k8s) version [=v0.3.0](https://github.com/aws/aws-app-mesh-controller-for-k8s/blob/legacy-controller/CHANGELOG.md)
 
+2. Install Docker. It is needed to build the demo application images
+
+## Setup environment
 - Setup following environment variables
   - **Your** account id:
     ```

--- a/walkthroughs/howto-k8s-grpc/README.md
+++ b/walkthroughs/howto-k8s-grpc/README.md
@@ -11,7 +11,7 @@ $ kubectl get deployment -n appmesh-system appmesh-controller -o json | jq -r ".
 
 You can use v1beta1 example manifest with [aws-app-mesh-controller-for-k8s](https://github.com/aws/aws-app-mesh-controller-for-k8s) version [=v0.3.0](https://github.com/aws/aws-app-mesh-controller-for-k8s/blob/legacy-controller/CHANGELOG.md)
 
-3. Install Docker. It is needed to build the demo application images
+3. Install Docker. It is needed to build the demo application images.
 
 ## Setup
 

--- a/walkthroughs/howto-k8s-grpc/README.md
+++ b/walkthroughs/howto-k8s-grpc/README.md
@@ -2,14 +2,16 @@
 This example shows how to manage gRPC routes in App Mesh using Kubernetes deployments.
 
 ## Prerequisites
-[Walkthrough: App Mesh with EKS](../eks/)
+1. [Walkthrough: App Mesh with EKS](../eks/)
 
-v1beta2 example manifest requires [aws-app-mesh-controller-for-k8s](https://github.com/aws/aws-app-mesh-controller-for-k8s) version [>=v1.0.0](https://github.com/aws/aws-app-mesh-controller-for-k8s/releases/tag/v1.0.0). Run the following to check the version of controller you are running.
+2. v1beta2 example manifest requires [aws-app-mesh-controller-for-k8s](https://github.com/aws/aws-app-mesh-controller-for-k8s) version [>=v1.0.0](https://github.com/aws/aws-app-mesh-controller-for-k8s/releases/tag/v1.0.0). Run the following to check the version of controller you are running.
 ```
 $ kubectl get deployment -n appmesh-system appmesh-controller -o json | jq -r ".spec.template.spec.containers[].image" | cut -f2 -d ':'|tail -n1
 ```
 
 You can use v1beta1 example manifest with [aws-app-mesh-controller-for-k8s](https://github.com/aws/aws-app-mesh-controller-for-k8s) version [=v0.3.0](https://github.com/aws/aws-app-mesh-controller-for-k8s/blob/legacy-controller/CHANGELOG.md)
+
+3. Install Docker. It is needed to build the demo application images
 
 ## Setup
 

--- a/walkthroughs/howto-k8s-http-headers/README.md
+++ b/walkthroughs/howto-k8s-http-headers/README.md
@@ -11,7 +11,7 @@ $ kubectl get deployment -n appmesh-system appmesh-controller -o json | jq -r ".
 
 You can use v1beta1 example manifest with [aws-app-mesh-controller-for-k8s](https://github.com/aws/aws-app-mesh-controller-for-k8s) version [=v0.3.0](https://github.com/aws/aws-app-mesh-controller-for-k8s/blob/legacy-controller/CHANGELOG.md)
 
-3. Install Docker. It is needed to build the demo application images
+3. Install Docker. It is needed to build the demo application images.
 
 ```
 ## Setup

--- a/walkthroughs/howto-k8s-http-headers/README.md
+++ b/walkthroughs/howto-k8s-http-headers/README.md
@@ -2,14 +2,16 @@
 This example shows how http routes can use headers for matching incoming requests.
 
 ## Prerequisites
-[Walkthrough: App Mesh with EKS](../eks/)
+1. [Walkthrough: App Mesh with EKS](../eks/)
 
-v1beta2 example manifest requires [aws-app-mesh-controller-for-k8s](https://github.com/aws/aws-app-mesh-controller-for-k8s) version [>=v1.0.0](https://github.com/aws/aws-app-mesh-controller-for-k8s/releases/tag/v1.0.0). Run the following to check the version of controller you are running.
+2. v1beta2 example manifest requires [aws-app-mesh-controller-for-k8s](https://github.com/aws/aws-app-mesh-controller-for-k8s) version [>=v1.0.0](https://github.com/aws/aws-app-mesh-controller-for-k8s/releases/tag/v1.0.0). Run the following to check the version of controller you are running.
 ```
 $ kubectl get deployment -n appmesh-system appmesh-controller -o json | jq -r ".spec.template.spec.containers[].image" | cut -f2 -d ':'|tail -n1
 ```
 
 You can use v1beta1 example manifest with [aws-app-mesh-controller-for-k8s](https://github.com/aws/aws-app-mesh-controller-for-k8s) version [=v0.3.0](https://github.com/aws/aws-app-mesh-controller-for-k8s/blob/legacy-controller/CHANGELOG.md)
+
+3. Install Docker. It is needed to build the demo application images
 
 ```
 ## Setup

--- a/walkthroughs/howto-k8s-http2/README.md
+++ b/walkthroughs/howto-k8s-http2/README.md
@@ -11,7 +11,7 @@ $ kubectl get deployment -n appmesh-system appmesh-controller -o json | jq -r ".
 
 You can use v1beta1 example manifest with [aws-app-mesh-controller-for-k8s](https://github.com/aws/aws-app-mesh-controller-for-k8s) version [=v0.3.0](https://github.com/aws/aws-app-mesh-controller-for-k8s/blob/legacy-controller/CHANGELOG.md)
 
-3. Install Docker. It is needed to build the demo application images
+3. Install Docker. It is needed to build the demo application images.
 
 ```
 ## Setup

--- a/walkthroughs/howto-k8s-http2/README.md
+++ b/walkthroughs/howto-k8s-http2/README.md
@@ -2,14 +2,16 @@
 This example shows how to manage HTTP/2 routes in App Mesh using Kubernetes deployments
 
 ## Prerequisites
-[Walkthrough: App Mesh with EKS](../eks/)
+1. [Walkthrough: App Mesh with EKS](../eks/)
 
-v1beta2 example manifest requires [aws-app-mesh-controller-for-k8s](https://github.com/aws/aws-app-mesh-controller-for-k8s) version [>=v1.0.0](https://github.com/aws/aws-app-mesh-controller-for-k8s/releases/tag/v1.0.0). Run the following to check the version of controller you are running.
+2. v1beta2 example manifest requires [aws-app-mesh-controller-for-k8s](https://github.com/aws/aws-app-mesh-controller-for-k8s) version [>=v1.0.0](https://github.com/aws/aws-app-mesh-controller-for-k8s/releases/tag/v1.0.0). Run the following to check the version of controller you are running.
 ```
 $ kubectl get deployment -n appmesh-system appmesh-controller -o json | jq -r ".spec.template.spec.containers[].image" | cut -f2 -d ':'|tail -n1
 ```
 
 You can use v1beta1 example manifest with [aws-app-mesh-controller-for-k8s](https://github.com/aws/aws-app-mesh-controller-for-k8s) version [=v0.3.0](https://github.com/aws/aws-app-mesh-controller-for-k8s/blob/legacy-controller/CHANGELOG.md)
+
+3. Install Docker. It is needed to build the demo application images
 
 ```
 ## Setup

--- a/walkthroughs/howto-k8s-ingress-gateway/README.md
+++ b/walkthroughs/howto-k8s-ingress-gateway/README.md
@@ -6,12 +6,14 @@ A virtual gateway allows resources outside your mesh to communicate to resources
 
 ## Prerequisites
 
-This example requires [aws-app-mesh-controller-for-k8s](https://github.com/aws/aws-app-mesh-controller-for-k8s) version [>=v1.1.0](https://github.com/aws/aws-app-mesh-controller-for-k8s/releases/tag/v1.1.0). Run the following to check the version of controller you are running.
+1. This example requires [aws-app-mesh-controller-for-k8s](https://github.com/aws/aws-app-mesh-controller-for-k8s) version [>=v1.1.0](https://github.com/aws/aws-app-mesh-controller-for-k8s/releases/tag/v1.1.0). Run the following to check the version of controller you are running.
 ```
 kubectl get deployment -n appmesh-system appmesh-controller -o json | jq -r ".spec.template.spec.containers[].image" | cut -f2 -d ':'|tail -n1
 
 v1.1.0
 ```
+
+2. Install Docker. It is needed to build the demo application images
 
 ## Setup
 

--- a/walkthroughs/howto-k8s-ingress-gateway/README.md
+++ b/walkthroughs/howto-k8s-ingress-gateway/README.md
@@ -13,7 +13,7 @@ kubectl get deployment -n appmesh-system appmesh-controller -o json | jq -r ".sp
 v1.1.0
 ```
 
-2. Install Docker. It is needed to build the demo application images
+2. Install Docker. It is needed to build the demo application images.
 
 ## Setup
 

--- a/walkthroughs/howto-k8s-mtls-sds-based/README.md
+++ b/walkthroughs/howto-k8s-mtls-sds-based/README.md
@@ -27,7 +27,7 @@ aws configure add-model \
     --service-model file://$HOME/appmesh-preview-model.json
 ```
 
-4. Install Docker. It is needed to build the demo application images
+4. Install Docker. It is needed to build the demo application images.
 
 ## Step 1: Setup Environment
 1. Clone this repository and navigate to the walkthrough/howto-k8s-mtls-sds-based folder, all commands will be ran from this location

--- a/walkthroughs/howto-k8s-mtls-sds-based/README.md
+++ b/walkthroughs/howto-k8s-mtls-sds-based/README.md
@@ -27,7 +27,7 @@ aws configure add-model \
     --service-model file://$HOME/appmesh-preview-model.json
 ```
 
-4. Install Docker. `deploy_app.sh` script builds the demo application images using Docker CLI.
+4. Install Docker. It is needed to build the demo application images
 
 ## Step 1: Setup Environment
 1. Clone this repository and navigate to the walkthrough/howto-k8s-mtls-sds-based folder, all commands will be ran from this location

--- a/walkthroughs/howto-k8s-outlier-detection/README.md
+++ b/walkthroughs/howto-k8s-outlier-detection/README.md
@@ -15,7 +15,7 @@ kubectl get deployment -n appmesh-system appmesh-controller -o json | jq -r ".sp
 v1.2.0
 ```
 
-3. Install Docker. `deploy.sh` script builds the demo application images using Docker CLI.
+3. Install Docker. It is needed to build the demo application images
 
 
 ## Step 1: Setup environment

--- a/walkthroughs/howto-k8s-outlier-detection/README.md
+++ b/walkthroughs/howto-k8s-outlier-detection/README.md
@@ -15,7 +15,7 @@ kubectl get deployment -n appmesh-system appmesh-controller -o json | jq -r ".sp
 v1.2.0
 ```
 
-3. Install Docker. It is needed to build the demo application images
+3. Install Docker. It is needed to build the demo application images.
 
 
 ## Step 1: Setup environment

--- a/walkthroughs/howto-k8s-retry-policy/README.md
+++ b/walkthroughs/howto-k8s-retry-policy/README.md
@@ -8,14 +8,16 @@ Color app serves color with optionally return error status code if a statuscode-
 Front app acts as a gateway that makes remote calls to colorapp. Front app has single deployment with pods registered with the mesh as _front_ virtual-node. This virtual-node uses colorapp virtual-service as backend.
 
 ## Prerequisites
-[Walkthrough: App Mesh with EKS](../eks/)
+1. [Walkthrough: App Mesh with EKS](../eks/)
 
-v1beta2 example manifest requires [aws-app-mesh-controller-for-k8s](https://github.com/aws/aws-app-mesh-controller-for-k8s) version [>=v1.0.0](https://github.com/aws/aws-app-mesh-controller-for-k8s/releases/tag/v1.0.0). Run the following to check the version of controller you are running.
+2. v1beta2 example manifest requires [aws-app-mesh-controller-for-k8s](https://github.com/aws/aws-app-mesh-controller-for-k8s) version [>=v1.0.0](https://github.com/aws/aws-app-mesh-controller-for-k8s/releases/tag/v1.0.0). Run the following to check the version of controller you are running.
 ```
 $ kubectl get deployment -n appmesh-system appmesh-controller -o json | jq -r ".spec.template.spec.containers[].image" | cut -f2 -d ':'|tail -n1
 ```
 
 You can use v1beta1 example manifest with [aws-app-mesh-controller-for-k8s](https://github.com/aws/aws-app-mesh-controller-for-k8s) version [=v0.3.0](https://github.com/aws/aws-app-mesh-controller-for-k8s/blob/legacy-controller/CHANGELOG.md)
+
+3. Install Docker. It is needed to build the demo application images
 
 ## Setup
 

--- a/walkthroughs/howto-k8s-retry-policy/README.md
+++ b/walkthroughs/howto-k8s-retry-policy/README.md
@@ -17,7 +17,7 @@ $ kubectl get deployment -n appmesh-system appmesh-controller -o json | jq -r ".
 
 You can use v1beta1 example manifest with [aws-app-mesh-controller-for-k8s](https://github.com/aws/aws-app-mesh-controller-for-k8s) version [=v0.3.0](https://github.com/aws/aws-app-mesh-controller-for-k8s/blob/legacy-controller/CHANGELOG.md)
 
-3. Install Docker. It is needed to build the demo application images
+3. Install Docker. It is needed to build the demo application images.
 
 ## Setup
 

--- a/walkthroughs/howto-k8s-timeout-policy/README.md
+++ b/walkthroughs/howto-k8s-timeout-policy/README.md
@@ -21,7 +21,7 @@ Colorapp is configured to respond with a delay of 45 seconds to simulate an upst
 ```
 $ kubectl get deployment -n appmesh-system appmesh-controller -o json | jq -r ".spec.template.spec.containers[].image" | cut -f2 -d ':'|tail -n1
 ```
-3. Install Docker. It is needed to build the demo application images
+3. Install Docker. It is needed to build the demo application images.
 
 ## Setup
 

--- a/walkthroughs/howto-k8s-timeout-policy/README.md
+++ b/walkthroughs/howto-k8s-timeout-policy/README.md
@@ -14,13 +14,14 @@ Front app acts as a gateway that makes remote calls to colorapp. Front app has s
 Colorapp is configured to respond with a delay of 45 seconds to simulate an upstream request that takes more than the default Envoy timeout of 15 seconds. Since, the configured timeout value in _front_virtual-node is 60 seconds(along with route timeout of 60 secs in the backend virtual router), we can see that envoy will not timeout in this scenario.
 
 ## Prerequisites
-[Walkthrough: App Mesh with EKS](../eks/)
+1. [Walkthrough: App Mesh with EKS](../eks/)
 
-v1beta2 example manifest requires aws-app-mesh-controller-for-k8s version >=v1.0.0. Run the following to check the version of controller you are running.
+2. v1beta2 example manifest requires aws-app-mesh-controller-for-k8s version >=v1.0.0. Run the following to check the version of controller you are running.
 
 ```
 $ kubectl get deployment -n appmesh-system appmesh-controller -o json | jq -r ".spec.template.spec.containers[].image" | cut -f2 -d ':'|tail -n1
 ```
+3. Install Docker. It is needed to build the demo application images
 
 ## Setup
 

--- a/walkthroughs/howto-k8s-tls-acm/README.md
+++ b/walkthroughs/howto-k8s-tls-acm/README.md
@@ -15,7 +15,7 @@ In this walkthrough we'll enable TLS encryption between two applications in App 
 $ kubectl get deployment -n appmesh-system appmesh-controller -o json | jq -r ".spec.template.spec.containers[].image" | cut -f2 -d ':'|tail -n1
 ```
 
-* Install Docker. It is needed to build the demo application images
+* Install Docker. It is needed to build the demo application images.
 
 
 

--- a/walkthroughs/howto-k8s-tls-acm/README.md
+++ b/walkthroughs/howto-k8s-tls-acm/README.md
@@ -10,11 +10,12 @@ In this walkthrough we'll enable TLS encryption between two applications in App 
     * `acm:ExportCertificate`
     * `acm-pca:GetCertificateAuthorityCertificate`
 
-The manifest in this walkthrough requires [aws-app-mesh-controller-for-k8s](https://github.com/aws/aws-app-mesh-controller-for-k8s) version [>=v1.0.0](https://github.com/aws/aws-app-mesh-controller-for-k8s/releases/tag/v1.0.0). Run the following to check the version of controller you are running.
+* The manifest in this walkthrough requires [aws-app-mesh-controller-for-k8s](https://github.com/aws/aws-app-mesh-controller-for-k8s) version [>=v1.0.0](https://github.com/aws/aws-app-mesh-controller-for-k8s/releases/tag/v1.0.0). Run the following to check the version of controller you are running.
 ```
 $ kubectl get deployment -n appmesh-system appmesh-controller -o json | jq -r ".spec.template.spec.containers[].image" | cut -f2 -d ':'|tail -n1
 ```
 
+* Install Docker. It is needed to build the demo application images
 
 
 

--- a/walkthroughs/howto-k8s-tls-file-based/README.md
+++ b/walkthroughs/howto-k8s-tls-file-based/README.md
@@ -4,12 +4,14 @@ In this walkthrough we'll enable TLS encryption between two applications in App 
 In App Mesh, traffic encryption works between Virtual Nodes, and thus between Envoys in your service mesh. This means your application code is not responsible for negotiating a TLS-encrypted session, instead allowing the local proxy to negotiate and terminate TLS on your application's behalf. We will be configuring Envoy to use the file based strategy (via Kubernetes Secrets) to setup certificates.
 
 ## Prerequisites
-[Walkthrough: App Mesh with EKS](../eks/)
+1. [Walkthrough: App Mesh with EKS](../eks/)
 
-The manifest in this walkthrough requires [aws-app-mesh-controller-for-k8s](https://github.com/aws/aws-app-mesh-controller-for-k8s) version [>=v1.0.0](https://github.com/aws/aws-app-mesh-controller-for-k8s/releases/tag/v1.0.0). Run the following to check the version of controller you are running.
+2. The manifest in this walkthrough requires [aws-app-mesh-controller-for-k8s](https://github.com/aws/aws-app-mesh-controller-for-k8s) version [>=v1.0.0](https://github.com/aws/aws-app-mesh-controller-for-k8s/releases/tag/v1.0.0). Run the following to check the version of controller you are running.
 ```
 $ kubectl get deployment -n appmesh-system appmesh-controller -o json | jq -r ".spec.template.spec.containers[].image" | cut -f2 -d ':'|tail -n1
 ```
+
+3. Install Docker. It is needed to build the demo application images
 
 ## Step 1: Setup environment
 1. Clone this repository and navigate to the walkthrough/howto-k8s-tls-file-based folder, all commands will be ran from this location

--- a/walkthroughs/howto-k8s-tls-file-based/README.md
+++ b/walkthroughs/howto-k8s-tls-file-based/README.md
@@ -11,7 +11,7 @@ In App Mesh, traffic encryption works between Virtual Nodes, and thus between En
 $ kubectl get deployment -n appmesh-system appmesh-controller -o json | jq -r ".spec.template.spec.containers[].image" | cut -f2 -d ':'|tail -n1
 ```
 
-3. Install Docker. It is needed to build the demo application images
+3. Install Docker. It is needed to build the demo application images.
 
 ## Step 1: Setup environment
 1. Clone this repository and navigate to the walkthrough/howto-k8s-tls-file-based folder, all commands will be ran from this location

--- a/walkthroughs/howto-mutual-tls-file-provided/README.md
+++ b/walkthroughs/howto-mutual-tls-file-provided/README.md
@@ -16,7 +16,7 @@ In this guide, we will be configuring Envoy proxies using certificates hosted in
 
 ## Prerequisites
 
-1. Install Docker. It is needed to build the demo application images
+1. Install Docker. It is needed to build the demo application images.
 
 ## Part 1: Setup
 

--- a/walkthroughs/howto-mutual-tls-file-provided/README.md
+++ b/walkthroughs/howto-mutual-tls-file-provided/README.md
@@ -14,6 +14,10 @@ Validation typically involves checking at least that the certificate is signed b
 
 In this guide, we will be configuring Envoy proxies using certificates hosted in AWS Secrets Manager, which a modified Envoy image will retrieve during startup. We will have a virtual gateway connected to a single backend service. Both the gateway and backend proxies will present certificates signed by the same Certificate Authority (CA), though you could choose to use separate CAs.
 
+## Prerequisites
+
+1. Install Docker. It is needed to build the demo application images
+
 ## Part 1: Setup
 
 ### Step 1: Download the App Mesh Preview CLI

--- a/walkthroughs/howto-outlier-detection/README.md
+++ b/walkthroughs/howto-outlier-detection/README.md
@@ -21,9 +21,9 @@ Here are the necessary fields to configure Outlier Detection:
 
 ## Step 1: Prerequisites
 
-You have version 1.18.172 or higher of the [AWS CLI v1](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv1.html) installed or you have version 2.0.62 or higher of the [AWS CLI v2](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) installed.
+1. You have version 1.18.172 or higher of the [AWS CLI v1](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv1.html) installed or you have version 2.0.62 or higher of the [AWS CLI v2](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) installed.
 
-To take a closer look at the related Envoy statistics for outlier detection, we will launch and SSH into a bastion host within the same VPC as the mesh to access the Envoy admin endpoint. Therefore we need an EC2 keypair for the bastion instance.
+2. To take a closer look at the related Envoy statistics for outlier detection, we will launch and SSH into a bastion host within the same VPC as the mesh to access the Envoy admin endpoint. Therefore we need an EC2 keypair for the bastion instance.
 You can create a keypair using the command below if you don't already have one. Otherwise follow export the key pair name instruction with the name of your key pair.
 
 ```bash
@@ -33,9 +33,11 @@ chmod 400 ~/.ssh/od-bastion.pem
 
 export the key pair name: ```bash export KEY_PAIR_NAME=od-bastion```
 
-In addition, this walkthrough makes use of the unix command line utility `jq`. If you don't already have it, you can install it from [here](https://stedolan.github.io/jq/).
+3. In addition, this walkthrough makes use of the unix command line utility `jq`. If you don't already have it, you can install it from [here](https://stedolan.github.io/jq/).
 
-Finally, to generate traffic and observe the server responses, we will leverage the open source Http load testing tool [vegeta](https://github.com/tsenart/vegeta). You can choose to install it locally or run the commands we will use later in a Docker container using this [image](https://hub.docker.com/r/peterevans/vegeta/).
+4. Install Docker. It is needed to build the demo application images
+
+5. Finally, to generate traffic and observe the server responses, we will leverage the open source Http load testing tool [vegeta](https://github.com/tsenart/vegeta). You can choose to install it locally or run the commands we will use later in a Docker container using this [image](https://hub.docker.com/r/peterevans/vegeta/).
 
 ## Step 2: Set Environment Variables
 

--- a/walkthroughs/howto-outlier-detection/README.md
+++ b/walkthroughs/howto-outlier-detection/README.md
@@ -35,7 +35,7 @@ export the key pair name: ```bash export KEY_PAIR_NAME=od-bastion```
 
 3. In addition, this walkthrough makes use of the unix command line utility `jq`. If you don't already have it, you can install it from [here](https://stedolan.github.io/jq/).
 
-4. Install Docker. It is needed to build the demo application images
+4. Install Docker. It is needed to build the demo application images.
 
 5. Finally, to generate traffic and observe the server responses, we will leverage the open source Http load testing tool [vegeta](https://github.com/tsenart/vegeta). You can choose to install it locally or run the commands we will use later in a Docker container using this [image](https://hub.docker.com/r/peterevans/vegeta/).
 

--- a/walkthroughs/howto-timeout-policy/README.md
+++ b/walkthroughs/howto-timeout-policy/README.md
@@ -34,7 +34,7 @@ This command creates an Amazon EC2 Key Pair with name `color-app` and saves the 
 `~/.ssh/color-app.pem`.
 
 3. Additionally, this walkthrough makes use of the unix command line utility jq. If you don't already have it, you can install it from [here](https://stedolan.github.io/jq/).
-4. Install Docker. It is needed to build the demo application images
+4. Install Docker. It is needed to build the demo application images.
 
 ## Step 2: Set Environment Variables
 

--- a/walkthroughs/howto-timeout-policy/README.md
+++ b/walkthroughs/howto-timeout-policy/README.md
@@ -15,7 +15,7 @@ However to increase the timeout (>15secs), it needs to be set at the route and a
 
 ## Step 1: Prerequisites
 
-We will need the latest version of the App Mesh Preview CLI for this walkthrough. You can download and use the latest version using the command below.
+1. We will need the latest version of the App Mesh Preview CLI for this walkthrough. You can download and use the latest version using the command below.
 
 ```bash
 aws configure add-model \
@@ -23,7 +23,7 @@ aws configure add-model \
         --service-model https://raw.githubusercontent.com/aws/aws-app-mesh-roadmap/master/appmesh-preview/service-model.json
 ```
 
-We'll also need a keypair stored in AWS to access a bastion host. You can create a keypair using the command below if you don't have one. See [Amazon EC2 Key Pairs](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html).
+2. We'll also need a keypair stored in AWS to access a bastion host. You can create a keypair using the command below if you don't have one. See [Amazon EC2 Key Pairs](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html).
 
 ```bash
 aws ec2 create-key-pair --key-name color-app | jq -r .KeyMaterial > ~/.ssh/color-app.pem
@@ -33,7 +33,8 @@ chmod go-r ~/.ssh/color-app.pem
 This command creates an Amazon EC2 Key Pair with name `color-app` and saves the private key at
 `~/.ssh/color-app.pem`.
 
-Additionally, this walkthrough makes use of the unix command line utility jq. If you don't already have it, you can install it from [here](https://stedolan.github.io/jq/).
+3. Additionally, this walkthrough makes use of the unix command line utility jq. If you don't already have it, you can install it from [here](https://stedolan.github.io/jq/).
+4. Install Docker. It is needed to build the demo application images
 
 ## Step 2: Set Environment Variables
 

--- a/walkthroughs/howto-tls-file-provided/README.md
+++ b/walkthroughs/howto-tls-file-provided/README.md
@@ -12,7 +12,7 @@ Additionally, this walkthrough makes use of the unix command line utility `jq`. 
 
 ## Prerequisites
 
-1. Install Docker. It is needed to build the demo application images
+1. Install Docker. It is needed to build the demo application images.
 
 ## Step 1: Create Color App Infrastructure
 

--- a/walkthroughs/howto-tls-file-provided/README.md
+++ b/walkthroughs/howto-tls-file-provided/README.md
@@ -10,6 +10,10 @@ In this guide, we will be configuring Envoy to use the file based strategy.
 
 Additionally, this walkthrough makes use of the unix command line utility `jq`. If you don't already have it, you can install it from [here](https://stedolan.github.io/jq/).
 
+## Prerequisites
+
+1. Install Docker. It is needed to build the demo application images
+
 ## Step 1: Create Color App Infrastructure
 
 We'll start by setting up the basic infrastructure for our services. All commands will be provided as if run from the same directory as this README.

--- a/walkthroughs/tls-with-acm/README.md
+++ b/walkthroughs/tls-with-acm/README.md
@@ -10,6 +10,10 @@ With ACM, you can host some or all of your Public Key Infrastructure (PKI) in AW
 
 Let's jump into a brief example of App Mesh TLS in action.
 
+## Prerequisites
+
+1. Install Docker. It is needed to build the demo application images
+
 ## Step 1: Create Color App Infrastructure
 
 We'll start by setting up the basic infrastructure for our services. All commands will be provided as if run from the same directory as this README.

--- a/walkthroughs/tls-with-acm/README.md
+++ b/walkthroughs/tls-with-acm/README.md
@@ -12,7 +12,7 @@ Let's jump into a brief example of App Mesh TLS in action.
 
 ## Prerequisites
 
-1. Install Docker. It is needed to build the demo application images
+1. Install Docker. It is needed to build the demo application images.
 
 ## Step 1: Create Color App Infrastructure
 


### PR DESCRIPTION
**Issue** #329 

**Description of changes**
For most of the walkthroughs, user has to build application containers at least once. Adding the documentation pre-requisite to install Docker for the walkthroughs


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
