### PR TITLE
Update ingress resource spec.rules

### DIFF
--- a/walkthroughs/howto-k8s-alb/v1beta2/manifest.yaml.template
+++ b/walkthroughs/howto-k8s-alb/v1beta2/manifest.yaml.template
@@ -289,6 +289,6 @@ spec:
   - http:
       paths:
       - backend:
-          serviceName: color
+          serviceName: front
           servicePort: 8080
         path: /color


### PR DESCRIPTION
Ingress resource should point to front service, as this is a public loadbalancer, then front service has color service as its backends

*Issue #, if available:*
although it's currently working fine but in the current design if front service and front deployment were deleted the app won't be affected because they are not being used
*Description of changes:*
modified the ingress resource to point to front service instead of color

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
