### PR TITLE
Fixing cfn resource dependency for howto-ecs-basics demo

### DIFF
--- a/walkthroughs/howto-ecs-basics/deploy/0-prelude.yaml
+++ b/walkthroughs/howto-ecs-basics/deploy/0-prelude.yaml
@@ -370,6 +370,8 @@ Resources:
 
   ColorECSService:
     Type: AWS::ECS::Service
+    DependsOn:
+      - ColorLoadBalancer
     Properties:
       Cluster: !Ref ECSCluster
       DeploymentConfiguration:


### PR DESCRIPTION
*Issue #, if available:*
There was a race condition where ECS service creation could fail because the LB has not been created yet.
The service creation fails with:
```
Invalid request provided: CreateService error: The target group with targetGroupArn arn:aws:elasticloadbalancing:us-west-2:XXXXXXXXXXXX:targetgroup/howto-ecs-basics-colortarget/f7bc7d2e2dd3455f does not have an associated load balancer.
```

*Description of changes:*
Added CFN dependency on the ECS service to wait on LB creation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
