### PR TITLE
README and SPIRE selector updates

### DIFF
--- a/walkthroughs/howto-k8s-mtls-sds-based/README.md
+++ b/walkthroughs/howto-k8s-mtls-sds-based/README.md
@@ -57,6 +57,7 @@ Walk through uses built-in k8s node attestor([k8s_sat](https://github.com/spiffe
 ```bash
 ./deploy_spire.sh
 ```
+**Note:** You can also install sample SPIRE Server and Agent via helm. Please refer to [SPIRE Server](https://github.com/aws/eks-charts/tree/master/stable/appmesh-spire-server) and [SPIRE Agent](https://github.com/aws/eks-charts/tree/master/stable/appmesh-spire-agent) charts in EKS charts repository for instructions on how to install them. If you prefer to install SPIRE via the sample helm charts for this walkthrough then please make sure to set the SPIRE trust domain to `howto-k8s-mtls-sds-based.aws` (--set config.trustDomain=howto-k8s-mtls-sds-based.aws)
 
 Let's check if both SPIRE Server and Agent are up and running. You should see a SPIRE Agent up and running on every node on your cluster.
 

--- a/walkthroughs/howto-k8s-mtls-sds-based/spire/register_server_entries.sh
+++ b/walkthroughs/howto-k8s-mtls-sds-based/spire/register_server_entries.sh
@@ -11,7 +11,7 @@ if [ "$1" == "register" ]; then
   echo "Registering an entry for spire agent..."
   register_server_entries \
     -spiffeID spiffe://howto-k8s-mtls-sds-based.aws/ns/spire/sa/spire-agent \
-    -selector k8s_sat:cluster:eks-cluster \
+    -selector k8s_sat:cluster:k8s-cluster \
     -selector k8s_sat:agent_ns:spire \
     -selector k8s_sat:agent_sa:spire-agent \
     -node

--- a/walkthroughs/howto-k8s-mtls-sds-based/spire/spire_setup.yaml
+++ b/walkthroughs/howto-k8s-mtls-sds-based/spire/spire_setup.yaml
@@ -105,7 +105,7 @@ data:
       NodeAttestor "k8s_sat" {
         plugin_data {
           clusters = {
-            "eks-cluster" = {
+            "k8s-cluster" = {
               use_token_review_api_validation = true
               service_account_whitelist = ["spire:spire-agent"]
             }
@@ -224,7 +224,7 @@ data:
     plugins {
       NodeAttestor "k8s_sat" {
         plugin_data {
-          cluster = "eks-cluster"
+          cluster = "k8s-cluster"
         }
       }
 


### PR DESCRIPTION
*Issue #, if available:*
NA
*Description of changes:*

Added a note in README about the helm based install option for SPIRE setup. Also, updated sample cluster name used in the node attestor and config to reflect the change we recently made in SPIRE helm repo.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
