### PR TITLE
Removing the namespace flag from the walkthrough instruction.

### DIFF
--- a/walkthroughs/howto-k8s-http-headers/README.md
+++ b/walkthroughs/howto-k8s-http-headers/README.md
@@ -36,7 +36,7 @@ You can use v1beta1 example manifest with [aws-app-mesh-controller-for-k8s](http
 
 Add a curler to the namespace howto-k8s-http-headers on your cluster -
 ```
-kubectl -n howto-k8s-http-headers run -it curler --image=tutum/curl /bin/bash
+kubectl run -it curler --image=tutum/curl /bin/bash
 ```
 
 Run the commands on curler to test.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Removed the invalid Namespace flag from howto-k8s-http-headers walkthrough first instruction

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
