### PR TITLE
Removed namespace from howto-k8s-http-headers walkthrough example ins…

### DIFF
--- a/walkthroughs/howto-k8s-http-headers/README.md
+++ b/walkthroughs/howto-k8s-http-headers/README.md
@@ -34,9 +34,9 @@ You can use v1beta1 example manifest with [aws-app-mesh-controller-for-k8s](http
 
 ## Using curl to test
 
-Add a curler to the namespace howto-k8s-http-headers on your cluster -
+Add a curler on your cluster -
 ```
-kubectl -n howto-k8s-http-headers run -it curler --image=tutum/curl /bin/bash
+kubectl run -it curler --image=tutum/curl /bin/bash
 ```
 
 Run the commands on curler to test.


### PR DESCRIPTION
…truction

*Issue #, if available:*

*Description of changes:*
Removed invalid namespace from the first instruction in howto-k8s-http-headers walkthrough example

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
