### PR TITLE
Update readme and added required vpc_id env var

### DIFF
--- a/walkthroughs/howto-k8s-http2/README.md
+++ b/walkthroughs/howto-k8s-http2/README.md
@@ -6,40 +6,48 @@ This example shows how to manage HTTP/2 routes in App Mesh using Kubernetes depl
 
 2. v1beta2 example manifest requires [aws-app-mesh-controller-for-k8s](https://github.com/aws/aws-app-mesh-controller-for-k8s) version [>=v1.0.0](https://github.com/aws/aws-app-mesh-controller-for-k8s/releases/tag/v1.0.0). Run the following to check the version of controller you are running.
 ```
-$ kubectl get deployment -n appmesh-system appmesh-controller -o json | jq -r ".spec.template.spec.containers[].image" | cut -f2 -d ':'|tail -n1
+kubectl get deployment -n appmesh-system appmesh-controller -o json | jq -r ".spec.template.spec.containers[].image" | cut -f2 -d ':'|tail -n1
 ```
 
 You can use v1beta1 example manifest with [aws-app-mesh-controller-for-k8s](https://github.com/aws/aws-app-mesh-controller-for-k8s) version [=v0.3.0](https://github.com/aws/aws-app-mesh-controller-for-k8s/blob/legacy-controller/CHANGELOG.md)
 
 3. Install Docker. It is needed to build the demo application images.
 
-```
+
 ## Setup
 
-1. Clone this repository and navigate to the walkthrough/howto-k8s-http2 folder, all commands will be ran from this location
+Clone this repository and navigate to the walkthrough/howto-k8s-http2 folder, all commands will be ran from this location
 1. **Your** account id:
     ```
     export AWS_ACCOUNT_ID=<your_account_id>
     ```
-1. **Region** e.g. us-west-2
+   
+2. **Region** e.g. us-west-2
     ```
     export AWS_DEFAULT_REGION=us-west-2
     ```
-1. **(Optional) Specify Envoy Image version** If you'd like to use a different Envoy image version than the [default](https://github.com/aws/eks-charts/tree/master/stable/appmesh-controller#configuration), run `helm upgrade` to override the `sidecar.image.repository` and `sidecar.image.tag` fields, e.g.
+   
+3. Find and export your VPC ID where your k8s is installed in EKS
+   ```
+   export VPC_ID=<your_vpc_id>
+   ```
+   
+4. **(Optional) Specify Envoy Image version** If you'd like to use a different Envoy image version than the [default](https://github.com/aws/eks-charts/tree/master/stable/appmesh-controller#configuration), run `helm upgrade` to override the `sidecar.image.repository` and `sidecar.image.tag` fields, e.g.
     ```
     helm upgrade -i appmesh-controller eks/appmesh-controller --namespace appmesh-system --set sidecar.image.repository=840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-envoy --set sidecar.image.tag=<VERSION>
     ```
-1. Deploy
+   
+5. Deploy
     ```.
     ./deploy.sh
     ```   
     
-1. Note that the example apps use go modules. If you have trouble accessing https://proxy.golang.org during the deployment you can override the GOPROXY by setting `GO_PROXY=direct`
+6. Note that the example apps use go modules. If you have trouble accessing https://proxy.golang.org during the deployment you can override the GOPROXY by setting `GO_PROXY=direct`
    ```
    GO_PROXY=direct ./deploy.sh
    ``` 
        
-1. Set up [port forwarding](https://kubernetes.io/docs/tasks/access-application-cluster/port-forward-access-application-cluster/) to route requests from your local computer to the **client** pod. The local port is up to you but we will assume the local port is **7000** for this walkthrough.
+7. Set up [port forwarding](https://kubernetes.io/docs/tasks/access-application-cluster/port-forward-access-application-cluster/) to route requests from your local computer to the **client** pod. The local port is up to you but we will assume the local port is **7000** for this walkthrough.
 
     
 ## HTTP/2 Routing
@@ -48,15 +56,15 @@ You can use v1beta1 example manifest with [aws-app-mesh-controller-for-k8s](http
     kubectl get pod -n <namespace>
     ```  
     
-1. Using the name of the client pod run the following command to tail the client app logs:
+2. Using the name of the client pod run the following command to tail the client app logs:
     ```
     kubectl logs -f -n <namespace> <pod_name> app
     ```
 
-1. Initially the state of your mesh is a client node with an even distribution to 3 color services (red, blue, and green) over HTTP/2. Prove this by running the following command a few times:
+3. Initially the state of your mesh is a client node with an even distribution to 3 color services (red, blue, and green) over HTTP/2. Prove this by running the following command a few times:
     ```
     curl localhost:7000/color
     ```
    
-1. You can edit these specifications in the manifest.yaml.template [here](./manifest.yaml.template). Run ./deploy.sh after any changes you make. For instance you can remove one of the weighted targets and trigger the curl command above to confirm that color route no longer appears.
+4. You can edit these specifications in the manifest.yaml.template [here](./manifest.yaml.template). Run ./deploy.sh after any changes you make. For instance you can remove one of the weighted targets and trigger the curl command above to confirm that color route no longer appears.
 

--- a/walkthroughs/howto-k8s-http2/deploy.sh
+++ b/walkthroughs/howto-k8s-http2/deploy.sh
@@ -12,6 +12,11 @@ if [ -z $AWS_DEFAULT_REGION ]; then
     exit 1
 fi
 
+if [ -z $VPC_ID ]; then
+    echo "VPC_ID environment variable is not set."
+    exit 1
+fi
+
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
 PROJECT_NAME="howto-k8s-http2"
 APP_NAMESPACE=${PROJECT_NAME}


### PR DESCRIPTION
*Issue #, if available:*
VPC_ID is required when running ./deploy.sh

*Description of changes:*
Fix messy readme, added bullet point for exporting VPC_ID environment variable.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
