### PR TITLE
Remove unnecessary health check path in gRPC example

### DIFF
--- a/walkthroughs/howto-k8s-grpc/v1beta1/manifest.yaml.template
+++ b/walkthroughs/howto-k8s-grpc/v1beta1/manifest.yaml.template
@@ -44,7 +44,6 @@ spec:
       healthCheck:
         port: 8080
         protocol: grpc
-        path: '/ping'
         healthyThreshold: 2
         unhealthyThreshold: 3
         timeoutMillis: 2000

--- a/walkthroughs/howto-k8s-grpc/v1beta2/manifest.yaml.template
+++ b/walkthroughs/howto-k8s-grpc/v1beta2/manifest.yaml.template
@@ -55,7 +55,6 @@ spec:
       healthCheck:
         port: 8080
         protocol: grpc
-        path: '/ping'
         healthyThreshold: 2
         unhealthyThreshold: 3
         timeoutMillis: 2000


### PR DESCRIPTION
*Issue #, if available:*

According to the document [1] [2], is mentioning about the definition of HealthCheckPolicy for VirtualNode, the `path` property will only be effective when using  HTTP or HTTP/2:

> **path**
> The destination path for the health check request. This value is only used if the specified protocol is HTTP or HTTP/2. For any other protocol, this value is ignored.

If using `grpc` as health check protocol, it will use [gRPC health check Protocol](https://github.com/grpc/grpc/blob/master/doc/health-checking.md) that should be implemented in application code:

> **protocol**
> The protocol for the health check request. If you specify grpc, then your service must conform to the [GRPC Health Checking Protocol.](https://github.com/grpc/grpc/blob/master/doc/health-checking.md)



[1] HealthCheckPolicy - https://docs.aws.amazon.com/app-mesh/latest/APIReference/API_HealthCheckPolicy.html
[2] AWS::AppMesh::VirtualNode HealthCheck - Properties - https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appmesh-virtualnode-healthcheck.html#aws-properties-appmesh-virtualnode-healthcheck-properties

---

*Description of changes:*

I can see the similar example did not specify this field:

https://github.com/aws/aws-app-mesh-examples/blob/5a2d04227593d292d52e5e2ca638d808ebed5e70/walkthroughs/howto-grpc/mesh.yaml#L30-L46

It made me confused when I was start to read the manifest file. After getting a try without `path`, I can see that it is not required and App Mesh still able to deploy my VirtualNode.

So I removed the `path` in the manifest as it is not required when health check is using gRPC protocol to make sure it won't cause confusion. As the sample application already implemented `Check` and `Watch` method:

https://github.com/aws/aws-app-mesh-examples/blob/5a2d04227593d292d52e5e2ca638d808ebed5e70/walkthroughs/howto-k8s-grpc/color_server/main.go#L52-L60

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
