### PR TITLE
Updating cross account demo to use cloudmap service discovery

### DIFF
--- a/walkthroughs/howto-cross-account/README.md
+++ b/walkthroughs/howto-cross-account/README.md
@@ -27,7 +27,7 @@ These backends will be configured in distinct accounts and made accessible throu
     cd walkthroughs/howto-cross-account
     ```
 2. Edit the `vars.env` file to add your account and profile settings:
-    
+
     1. **Project Name** used to isolate resources created in this demo from other's in your account. e.g. howto-cross-account
         ```
         export PROJECT_NAME=howto-cross-account
@@ -69,9 +69,9 @@ These backends will be configured in distinct accounts and made accessible throu
         ```
         export AWS_DEFAULT_REGION=us-west-2
         ```
-    5. **ENVOY_IMAGE** set to the location of the App Mesh Envoy container image, see https://docs.aws.amazon.com/app-mesh/latest/userguide/envoy.html
+    5. **ENVOY_IMAGE** set to the location of the App Mesh Envoy container image, see https://gallery.ecr.aws/appmesh/aws-appmesh-envoy
         ```
-        export ENVOY_IMAGE=840364872350.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/aws-appmesh-envoy:v1.12.2.1-prod
+        export ENVOY_IMAGE=public.ecr.aws/appmesh/aws-appmesh-envoy:v1.18.3.0-prod
         ```
     6. **Backend Images**
         ```

--- a/walkthroughs/howto-cross-account/primary-account/app.yaml
+++ b/walkthroughs/howto-cross-account/primary-account/app.yaml
@@ -44,7 +44,8 @@ Resources:
     Type: AWS::ElasticLoadBalancingV2::TargetGroup
     Properties:
       HealthCheckIntervalSeconds: 6
-      HealthCheckPath: '/elb-status'
+      HealthCheckPath: '/ready'
+      HealthCheckPort: 9901
       HealthCheckProtocol: HTTP
       HealthCheckTimeoutSeconds: 5
       HealthyThresholdCount: 2

--- a/walkthroughs/howto-cross-account/primary-account/infra.yaml
+++ b/walkthroughs/howto-cross-account/primary-account/infra.yaml
@@ -12,7 +12,7 @@ Parameters:
     Description: EC2 AMI ID
     Default: '/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2'
 
-  VpcCIDR: 
+  VpcCIDR:
     Description: Please enter the IP range (CIDR notation) for this VPC
     Type: String
     Default: 10.0.0.0/16
@@ -38,76 +38,76 @@ Parameters:
     Default: 10.0.96.0/19
 
 Resources:
-  VPC: 
+  VPC:
     Type: AWS::EC2::VPC
     Properties:
       CidrBlock: !Ref VpcCIDR
       EnableDnsHostnames: true
-      Tags: 
-      - Key: Name 
+      Tags:
+      - Key: Name
         Value: !Ref ProjectName
-      
+
   InternetGateway:
     Type: AWS::EC2::InternetGateway
     Properties:
       Tags:
       - Key: Name
         Value: !Ref ProjectName
-      
+
   InternetGatewayAttachment:
     Type: AWS::EC2::VPCGatewayAttachment
     Properties:
       InternetGatewayId: !Ref InternetGateway
       VpcId: !Ref VPC
 
-  PublicSubnet1: 
+  PublicSubnet1:
     Type: AWS::EC2::Subnet
     Properties:
       VpcId: !Ref VPC
       AvailabilityZone: !Select [ 0, !GetAZs '' ]
       CidrBlock: !Ref PublicSubnet1CIDR
       MapPublicIpOnLaunch: true
-      Tags: 
-      - Key: Name 
+      Tags:
+      - Key: Name
         Value: !Sub '${ProjectName} Public Subnet (AZ1)'
 
-  PublicSubnet2: 
+  PublicSubnet2:
     Type: AWS::EC2::Subnet
     Properties:
       VpcId: !Ref VPC
       AvailabilityZone: !Select [ 1, !GetAZs '' ]
       CidrBlock: !Ref PublicSubnet2CIDR
       MapPublicIpOnLaunch: true
-      Tags: 
-      - Key: Name 
+      Tags:
+      - Key: Name
         Value: !Sub '${ProjectName} Public Subnet (AZ2)'
 
-  PrivateSubnet1: 
+  PrivateSubnet1:
     Type: AWS::EC2::Subnet
     Properties:
       VpcId: !Ref VPC
       AvailabilityZone: !Select [ 0, !GetAZs '' ]
       CidrBlock: !Ref PrivateSubnet1CIDR
       MapPublicIpOnLaunch: false
-      Tags: 
-      - Key: Name 
+      Tags:
+      - Key: Name
         Value: !Sub '${ProjectName} Private Subnet (AZ1)'
 
-  PrivateSubnet2: 
+  PrivateSubnet2:
     Type: AWS::EC2::Subnet
     Properties:
       VpcId: !Ref VPC
       AvailabilityZone: !Select [ 1, !GetAZs '' ]
       CidrBlock: !Ref PrivateSubnet2CIDR
       MapPublicIpOnLaunch: false
-      Tags: 
-      - Key: Name 
+      Tags:
+      - Key: Name
         Value: !Sub '${ProjectName} Private Subnet (AZ2)'
 
   NatGateway1EIP:
     Type: AWS::EC2::EIP
     DependsOn: InternetGatewayAttachment
-    Properties: 
+    Properties:
       Domain: vpc
 
   NatGateway2EIP:
@@ -116,13 +116,13 @@ Resources:
     Properties:
       Domain: vpc
 
-  NatGateway1: 
+  NatGateway1:
     Type: AWS::EC2::NatGateway
-    Properties: 
+    Properties:
       AllocationId: !GetAtt NatGateway1EIP.AllocationId
       SubnetId: !Ref PublicSubnet1
 
-  NatGateway2: 
+  NatGateway2:
     Type: AWS::EC2::NatGateway
     Properties:
       AllocationId: !GetAtt NatGateway2EIP.AllocationId
@@ -130,16 +130,16 @@ Resources:
 
   PublicRouteTable:
     Type: AWS::EC2::RouteTable
-    Properties: 
+    Properties:
       VpcId: !Ref VPC
-      Tags: 
-      - Key: Name 
+      Tags:
+      - Key: Name
         Value: !Sub '${ProjectName} Public Routes'
 
-  DefaultPublicRoute: 
+  DefaultPublicRoute:
     Type: AWS::EC2::Route
     DependsOn: InternetGatewayAttachment
-    Properties: 
+    Properties:
       RouteTableId: !Ref PublicRouteTable
       DestinationCidrBlock: 0.0.0.0/0
       GatewayId: !Ref InternetGateway
@@ -155,13 +155,13 @@ Resources:
     Properties:
       RouteTableId: !Ref PublicRouteTable
       SubnetId: !Ref PublicSubnet2
-  
+
   PrivateRouteTable1:
     Type: AWS::EC2::RouteTable
-    Properties: 
+    Properties:
       VpcId: !Ref VPC
-      Tags: 
-      - Key: Name 
+      Tags:
+      - Key: Name
         Value: !Sub '${ProjectName} Private Routes (AZ1)'
 
   DefaultPrivateRoute1:
@@ -179,10 +179,10 @@ Resources:
 
   PrivateRouteTable2:
     Type: AWS::EC2::RouteTable
-    Properties: 
+    Properties:
       VpcId: !Ref VPC
-      Tags: 
-      - Key: Name 
+      Tags:
+      - Key: Name
         Value: !Sub '${ProjectName} Private Routes (AZ2)'
 
   DefaultPrivateRoute2:
@@ -234,31 +234,31 @@ Outputs:
   VPC:
     Description: A reference to the created VPC
     Value: !Ref VPC
-    Export: 
+    Export:
       Name: !Sub '${ProjectName}:VPC'
 
   PublicSubnet1:
     Description: A reference to the public subnet in the 1st Availability Zone
     Value: !Ref PublicSubnet1
-    Export: 
+    Export:
       Name: !Sub '${ProjectName}:PublicSubnet1'
 
-  PublicSubnet2: 
+  PublicSubnet2:
     Description: A reference to the public subnet in the 2nd Availability Zone
     Value: !Ref PublicSubnet2
-    Export: 
+    Export:
       Name: !Sub '${ProjectName}:PublicSubnet2'
 
   PrivateSubnet1:
     Description: A reference to the private subnet in the 1st Availability Zone
     Value: !Ref PrivateSubnet1
-    Export: 
+    Export:
       Name: !Sub '${ProjectName}:PrivateSubnet1'
 
-  PrivateSubnet2: 
+  PrivateSubnet2:
     Description: A reference to the private subnet in the 2nd Availability Zone
     Value: !Ref PrivateSubnet2
-    Export: 
+    Export:
       Name: !Sub '${ProjectName}:PrivateSubnet2'
 
   VpcCIDR:

--- a/walkthroughs/howto-cross-account/primary-account/mesh.yaml
+++ b/walkthroughs/howto-cross-account/primary-account/mesh.yaml
@@ -11,10 +11,10 @@ Resources:
 
   VirtualGateway:
     Type: AWS::AppMesh::VirtualGateway
-    Properties: 
+    Properties:
       MeshName: !GetAtt Mesh.MeshName
-      Spec: 
-        Listeners: 
+      Spec:
+        Listeners:
         - PortMapping:
             Port: 80
             Protocol: http
@@ -22,7 +22,7 @@ Resources:
 
   GatewayRoute:
     Type: AWS::AppMesh::GatewayRoute
-    Properties: 
+    Properties:
       GatewayRouteName: gateway-gr
       MeshName: !GetAtt Mesh.MeshName
       Spec:
@@ -46,9 +46,10 @@ Resources:
             Port: 80
             Protocol: http
         ServiceDiscovery:
-          DNS:
-            Hostname: !Sub "backend.${ProjectName}.local"
-              
+          AWSCloudMap:
+            NamespaceName: !Sub '${ProjectName}.local'
+            ServiceName: backend
+
   VirtualRouter:
     Type: AWS::AppMesh::VirtualRouter
     Properties:

--- a/walkthroughs/howto-cross-account/secondary-account/app.yaml
+++ b/walkthroughs/howto-cross-account/secondary-account/app.yaml
@@ -99,12 +99,8 @@ Resources:
     Type: AWS::ServiceDiscovery::Service
     Properties:
       Name: 'backend'
-      DnsConfig:
-        NamespaceId:
-          Fn::ImportValue: !Sub '${ProjectName}:ECSServiceDiscoveryNamespace'
-        DnsRecords:
-        - Type: A
-          TTL: 300
+      NamespaceId:
+        Fn::ImportValue: !Sub '${ProjectName}:ECSServiceDiscoveryNamespace'
       HealthCheckCustomConfig:
         FailureThreshold: 1
 

--- a/walkthroughs/howto-cross-account/secondary-account/infra.yaml
+++ b/walkthroughs/howto-cross-account/secondary-account/infra.yaml
@@ -14,10 +14,9 @@ Resources:
       ClusterName: !Ref ProjectName
 
   ECSServiceDiscoveryNamespace:
-    Type: AWS::ServiceDiscovery::PrivateDnsNamespace
+    Type: AWS::ServiceDiscovery::HttpNamespace
     Properties:
       Name: !Sub 'secondary.${ProjectName}.local'
-      Vpc: !Ref VPC
 
 Outputs:
   ECSCluster:

--- a/walkthroughs/howto-cross-account/secondary-account/mesh.yaml
+++ b/walkthroughs/howto-cross-account/secondary-account/mesh.yaml
@@ -22,5 +22,6 @@ Resources:
             Port: 80
             Protocol: http
         ServiceDiscovery:
-          DNS:
-            Hostname: !Sub "backend.secondary.${ProjectName}.local"
+          AWSCloudMap:
+            NamespaceName: !Sub 'secondary.${ProjectName}.local'
+            ServiceName: backend


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-app-mesh-examples/issues/432

*Description of changes:*
Due to change in behavior with RAM/VPC sharing integration. AppMesh cross account feature currently does not work with DNS based service discovery. This PR updates the demo to use CloudMap HTTP namespace based service discovery.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
