### PR TITLE
Markdown typo fix in howto-k8s-http2 README

### DIFF
--- a/walkthroughs/howto-k8s-http2/README.md
+++ b/walkthroughs/howto-k8s-http2/README.md
@@ -13,7 +13,7 @@ You can use v1beta1 example manifest with [aws-app-mesh-controller-for-k8s](http
 
 3. Install Docker. It is needed to build the demo application images.
 
-```
+
 ## Setup
 
 1. Clone this repository and navigate to the walkthrough/howto-k8s-http2 folder, all commands will be ran from this location


### PR DESCRIPTION

**Description of changes:**

If we navigate to this [README](https://github.com/aws/aws-app-mesh-examples/tree/main/walkthroughs/howto-k8s-http2) the Markdown alignment is messed up. So this PR will remove unwanted  \`\`\`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
