### PR TITLE
upgrades SPIRE version to support SDS V3

### DIFF
--- a/walkthroughs/howto-k8s-mtls-sds-based/spire/spire_setup.yaml
+++ b/walkthroughs/howto-k8s-mtls-sds-based/spire/spire_setup.yaml
@@ -151,7 +151,7 @@ spec:
       serviceAccountName: spire-server
       containers:
         - name: spire-server
-          image: gcr.io/spiffe-io/spire-server:0.10.0
+          image: gcr.io/spiffe-io/spire-server:0.12.0
           args:
             - -config
             - /run/spire/config/server.conf
@@ -272,7 +272,7 @@ spec:
           args: ["-t", "30", "spire-server:8081"]
       containers:
         - name: spire-agent
-          image: gcr.io/spiffe-io/spire-agent:0.10.0
+          image: gcr.io/spiffe-io/spire-agent:0.12.0
           args: ["-config", "/run/spire/config/agent.conf"]
           volumeMounts:
             - name: spire-config


### PR DESCRIPTION
*Issue #, if available:*
related but orthogonal: https://github.com/aws/aws-app-mesh-roadmap/issues/367

*Description of changes:*
according to our Envoy docs https://docs.aws.amazon.com/app-mesh/latest/userguide/1.17-migration.html, we need to upgrade SPIRE version to 0.12.0 which is the first version that supports SDS v3. This allows Envoy versions > v1.17 which expects SDS v3 to work with SPIRE.

I've tested running the [mtls walkthrough](https://github.com/aws/aws-app-mesh-examples/tree/master/walkthroughs/howto-k8s-mtls-sds-based) using SPIRE 0.12.0 on both Envoy versions 1.16.1.1 (SDS v2) and 1.17.3.0 (SDS v3). 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
