### PR TITLE
Modify all the Dockerfile wholesale to reduce the image size

### DIFF
--- a/examples/apps/colorapp/src/colorteller/Dockerfile
+++ b/examples/apps/colorapp/src/colorteller/Dockerfile
@@ -16,8 +16,12 @@ RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix nocgo -o /aws-app-mesh-examples-colorapp-teller .
 
-FROM amazonlinux:2
-RUN yum install -y ca-certificates
+FROM public.ecr.aws/amazonlinux/amazonlinux:2
+RUN yum update -y && \
+    yum install -y ca-certificates && \
+    yum clean all && \
+    rm -rf /var/cache/yum
+
 COPY --from=builder /aws-app-mesh-examples-colorapp-teller /bin/aws-app-mesh-examples-colorapp-teller
 
 ENTRYPOINT ["/bin/aws-app-mesh-examples-colorapp-teller"]

--- a/examples/apps/colorapp/src/gateway/Dockerfile
+++ b/examples/apps/colorapp/src/gateway/Dockerfile
@@ -17,8 +17,12 @@ RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix nocgo -o /aws-app-mesh-examples-colorapp-gateway .
 
-FROM amazonlinux:2
-RUN yum install -y ca-certificates
+FROM public.ecr.aws/amazonlinux/amazonlinux:2
+RUN yum update -y && \
+    yum install -y ca-certificates && \
+    yum clean all && \
+    rm -rf /var/cache/yum
+
 COPY --from=builder /aws-app-mesh-examples-colorapp-gateway /bin/aws-app-mesh-examples-colorapp-gateway
 
 ENTRYPOINT ["/bin/aws-app-mesh-examples-colorapp-gateway"]

--- a/walkthroughs/howto-circuit-breakers/src/colorteller/Dockerfile
+++ b/walkthroughs/howto-circuit-breakers/src/colorteller/Dockerfile
@@ -17,8 +17,11 @@ RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix nocgo -o /src/colorteller .
 
-FROM amazonlinux:2
-RUN yum install -y ca-certificates
+FROM public.ecr.aws/amazonlinux/amazonlinux:2
+RUN yum update -y && \
+    yum install -y ca-certificates && \
+    yum clean all && \
+    rm -rf /var/cache/yum
 COPY --from=builder /src/colorteller /src/colorteller
 
 ENTRYPOINT ["/src/colorteller"]

--- a/walkthroughs/howto-circuit-breakers/src/wrktool/Dockerfile
+++ b/walkthroughs/howto-circuit-breakers/src/wrktool/Dockerfile
@@ -1,16 +1,19 @@
-FROM amazonlinux:2
+FROM public.ecr.aws/amazonlinux/amazonlinux:2
 
-RUN yum -y update
-RUN yum groupinstall -y "Development Tools"
-RUN yum -y install python3 procps openssl-devel git
-RUN pip3 install -q Flask requests
-
-# Install wrk2
-RUN mkdir /opt/wrk2 && \
+RUN yum update -y && \
+    yum groupinstall -y "Development Tools" && \
+    yum -y install python3 procps openssl-devel git && \
+    pip3 install -q Flask requests && \
+    # Install wrk2
+    mkdir /opt/wrk2 && \ 
     git clone https://github.com/giltene/wrk2.git /opt/wrk2 && \
     cd /opt/wrk2 && \
     make && \
     cp wrk /usr/local/bin && \
+    # Remove pip3 & git
+    yum -y remove python3-pip git-core && \
+    yum clean all && \
+    rm -rf /var/cache/yum && \
     cd
 
 COPY wrk.py /usr/bin/wrk.py
@@ -18,3 +21,4 @@ COPY wrk.py /usr/bin/wrk.py
 EXPOSE 80
 
 ENTRYPOINT ["python3", "/usr/bin/wrk.py"]
+

--- a/walkthroughs/howto-ecs-basics/src/colorapp/Dockerfile
+++ b/walkthroughs/howto-ecs-basics/src/colorapp/Dockerfile
@@ -16,8 +16,11 @@ RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix nocgo -o /aws-app-mesh-examples-colorapp .
 
-FROM amazonlinux:2
-RUN yum install -y ca-certificates
+FROM public.ecr.aws/amazonlinux/amazonlinux:2
+RUN yum update -y && \
+    yum install -y ca-certificates && \
+    yum clean all && \
+    rm -rf /var/cache/yum
 COPY --from=builder /aws-app-mesh-examples-colorapp /bin/aws-app-mesh-examples-colorapp
 
 ENTRYPOINT ["/bin/aws-app-mesh-examples-colorapp"]

--- a/walkthroughs/howto-ecs-basics/src/cwagent/Dockerfile
+++ b/walkthroughs/howto-ecs-basics/src/cwagent/Dockerfile
@@ -1,8 +1,10 @@
-FROM amazonlinux
-
-RUN yum install -y \
+FROM public.ecr.aws/amazonlinux/amazonlinux:2
+RUN yum update -y && \
+    yum install -y \
     shadow-utils \
-    https://s3.amazonaws.com/amazoncloudwatch-agent/amazon_linux/amd64/latest/amazon-cloudwatch-agent.rpm
+    https://s3.amazonaws.com/amazoncloudwatch-agent/amazon_linux/amd64/latest/amazon-cloudwatch-agent.rpm && \
+    yum clean all && \
+    rm -rf /var/cache/yum
 
 # NOTICE: copied from https://github.com/istio/istio/blob/master/docker/Dockerfile.base
 # Change ownership to allow agent to write generated files

--- a/walkthroughs/howto-ecs-basics/src/feapp/Dockerfile
+++ b/walkthroughs/howto-ecs-basics/src/feapp/Dockerfile
@@ -17,8 +17,11 @@ RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix nocgo -o /aws-app-mesh-examples-feapp .
 
-FROM amazonlinux:2
-RUN yum install -y ca-certificates
+FROM public.ecr.aws/amazonlinux/amazonlinux:2
+RUN yum update -y && \
+    yum install -y ca-certificates && \
+    yum clean all && \
+    rm -rf /var/cache/yum
 COPY --from=builder /aws-app-mesh-examples-feapp /bin/aws-app-mesh-examples-feapp
 
 ENTRYPOINT ["/bin/aws-app-mesh-examples-feapp"]

--- a/walkthroughs/howto-grpc-ingress-gateway/color_server/Dockerfile
+++ b/walkthroughs/howto-grpc-ingress-gateway/color_server/Dockerfile
@@ -17,8 +17,11 @@ RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix nocgo -o /color_server .
 
-FROM amazonlinux:2
-RUN yum install -y ca-certificates
+FROM public.ecr.aws/amazonlinux/amazonlinux:2
+RUN yum update -y && \
+    yum install -y ca-certificates && \
+    yum clean all && \
+    rm -rf /var/cache/yum
 COPY --from=builder /color_server /color_server
 
 ENTRYPOINT ["/color_server"]

--- a/walkthroughs/howto-grpc/color_client/Dockerfile
+++ b/walkthroughs/howto-grpc/color_client/Dockerfile
@@ -17,8 +17,11 @@ RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix nocgo -o /color_client .
 
-FROM amazonlinux:2
-RUN yum install -y ca-certificates
+FROM public.ecr.aws/amazonlinux/amazonlinux:2
+RUN yum update -y && \
+    yum install -y ca-certificates && \
+    yum clean all && \
+    rm -rf /var/cache/yum
 COPY --from=builder /color_client /color_client
 
 ENTRYPOINT ["/color_client"]

--- a/walkthroughs/howto-grpc/color_server/Dockerfile
+++ b/walkthroughs/howto-grpc/color_server/Dockerfile
@@ -17,8 +17,11 @@ RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix nocgo -o /color_server .
 
-FROM amazonlinux:2
-RUN yum install -y ca-certificates
+FROM public.ecr.aws/amazonlinux/amazonlinux:2
+RUN yum update -y && \
+    yum install -y ca-certificates && \
+    yum clean all && \
+    rm -rf /var/cache/yum
 COPY --from=builder /color_server /color_server
 
 ENTRYPOINT ["/color_server"]

--- a/walkthroughs/howto-http2/color_client/Dockerfile
+++ b/walkthroughs/howto-http2/color_client/Dockerfile
@@ -17,8 +17,11 @@ RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix nocgo -o /color_client .
 
-FROM amazonlinux:2
-RUN yum install -y ca-certificates
+FROM public.ecr.aws/amazonlinux/amazonlinux:2
+RUN yum update -y && \
+    yum install -y ca-certificates && \
+    yum clean all && \
+    rm -rf /var/cache/yum
 COPY --from=builder /color_client /color_client
 
 ENTRYPOINT ["/color_client"]

--- a/walkthroughs/howto-http2/color_server/Dockerfile
+++ b/walkthroughs/howto-http2/color_server/Dockerfile
@@ -17,8 +17,11 @@ RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix nocgo -o /color_server .
 
-FROM amazonlinux:2
-RUN yum install -y ca-certificates
+FROM public.ecr.aws/amazonlinux/amazonlinux:2
+RUN yum update -y && \
+    yum install -y ca-certificates && \
+    yum clean all && \
+    rm -rf /var/cache/yum
 COPY --from=builder /color_server /color_server
 
 ENTRYPOINT ["/color_server"]

--- a/walkthroughs/howto-k8s-connection-pools/colorapp/Dockerfile
+++ b/walkthroughs/howto-k8s-connection-pools/colorapp/Dockerfile
@@ -11,8 +11,11 @@ RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix nocgo -o /src/colorteller .
 
-FROM amazonlinux:2
-RUN yum install -y ca-certificates
+FROM public.ecr.aws/amazonlinux/amazonlinux:2
+RUN yum update -y && \
+    yum install -y ca-certificates && \
+    yum clean all && \
+    rm -rf /var/cache/yum
 COPY --from=builder /src/colorteller /src/colorteller
 
 ENTRYPOINT ["/src/colorteller"]

--- a/walkthroughs/howto-k8s-fargate/src/colorapp/Dockerfile
+++ b/walkthroughs/howto-k8s-fargate/src/colorapp/Dockerfile
@@ -16,8 +16,11 @@ RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix nocgo -o /aws-app-mesh-examples-colorapp .
 
-FROM amazonlinux:2
-RUN yum install -y ca-certificates
+FROM public.ecr.aws/amazonlinux/amazonlinux:2
+RUN yum update -y && \
+    yum install -y ca-certificates && \
+    yum clean all && \
+    rm -rf /var/cache/yum
 COPY --from=builder /aws-app-mesh-examples-colorapp /bin/aws-app-mesh-examples-colorapp
 
 ENTRYPOINT ["/bin/aws-app-mesh-examples-colorapp"]

--- a/walkthroughs/howto-k8s-fargate/src/feapp/Dockerfile
+++ b/walkthroughs/howto-k8s-fargate/src/feapp/Dockerfile
@@ -17,8 +17,11 @@ RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix nocgo -o /aws-app-mesh-examples-feapp .
 
-FROM amazonlinux:2
-RUN yum install -y ca-certificates
+FROM public.ecr.aws/amazonlinux/amazonlinux:2
+RUN yum update -y && \
+    yum install -y ca-certificates && \
+    yum clean all && \
+    rm -rf /var/cache/yum
 COPY --from=builder /aws-app-mesh-examples-feapp /bin/aws-app-mesh-examples-feapp
 
 ENTRYPOINT ["/bin/aws-app-mesh-examples-feapp"]

--- a/walkthroughs/howto-k8s-grpc-ingress-v2/greeter/Dockerfile
+++ b/walkthroughs/howto-k8s-grpc-ingress-v2/greeter/Dockerfile
@@ -15,7 +15,7 @@ RUN go mod download
 
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix nocgo -o greeter ./cmd/main.go
 
-FROM amazonlinux:2
+FROM public.ecr.aws/amazonlinux/amazonlinux:2
 COPY --from=builder /grpc_server/greeter ./greeter
 
 EXPOSE 9111

--- a/walkthroughs/howto-k8s-grpc/color_client/Dockerfile
+++ b/walkthroughs/howto-k8s-grpc/color_client/Dockerfile
@@ -17,8 +17,11 @@ RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix nocgo -o /color_client .
 
-FROM amazonlinux:2
-RUN yum install -y ca-certificates
+FROM public.ecr.aws/amazonlinux/amazonlinux:2
+RUN yum update -y && \
+    yum install -y ca-certificates && \
+    yum clean all && \
+    rm -rf /var/cache/yum
 COPY --from=builder /color_client /color_client
 
 ENTRYPOINT ["/color_client"]

--- a/walkthroughs/howto-k8s-grpc/color_server/Dockerfile
+++ b/walkthroughs/howto-k8s-grpc/color_server/Dockerfile
@@ -17,8 +17,11 @@ RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix nocgo -o /color_server .
 
-FROM amazonlinux:2
-RUN yum install -y ca-certificates
+FROM public.ecr.aws/amazonlinux/amazonlinux:2
+RUN yum update -y && \
+    yum install -y ca-certificates && \
+    yum clean all && \
+    rm -rf /var/cache/yum
 COPY --from=builder /color_server /color_server
 
 ENTRYPOINT ["/color_server"]

--- a/walkthroughs/howto-k8s-http2/color_client/Dockerfile
+++ b/walkthroughs/howto-k8s-http2/color_client/Dockerfile
@@ -17,8 +17,11 @@ RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix nocgo -o /color_client .
 
-FROM amazonlinux:2
-RUN yum install -y ca-certificates
+FROM public.ecr.aws/amazonlinux/amazonlinux:2
+RUN yum update -y && \
+    yum install -y ca-certificates && \
+    yum clean all && \
+    rm -rf /var/cache/yum
 COPY --from=builder /color_client /color_client
 
 ENTRYPOINT ["/color_client"]

--- a/walkthroughs/howto-k8s-http2/color_server/Dockerfile
+++ b/walkthroughs/howto-k8s-http2/color_server/Dockerfile
@@ -17,8 +17,11 @@ RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix nocgo -o /color_server .
 
-FROM amazonlinux:2
-RUN yum install -y ca-certificates
+FROM public.ecr.aws/amazonlinux/amazonlinux:2
+RUN yum update -y && \
+    yum install -y ca-certificates && \
+    yum clean all && \
+    rm -rf /var/cache/yum
 COPY --from=builder /color_server /color_server
 
 ENTRYPOINT ["/color_server"]

--- a/walkthroughs/howto-k8s-outlier-detection/colorapp/Dockerfile
+++ b/walkthroughs/howto-k8s-outlier-detection/colorapp/Dockerfile
@@ -12,8 +12,11 @@ RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix nocgo -o /aws-app-mesh-examples-colorapp .
 
-FROM amazonlinux:2
-RUN yum install -y ca-certificates
+FROM public.ecr.aws/amazonlinux/amazonlinux:2
+RUN yum update -y && \
+    yum install -y ca-certificates && \
+    yum clean all && \
+    rm -rf /var/cache/yum
 COPY --from=builder /aws-app-mesh-examples-colorapp bin/aws-app-mesh-examples-colorapp
 
 ENTRYPOINT ["/bin/aws-app-mesh-examples-colorapp"]

--- a/walkthroughs/howto-k8s-outlier-detection/feapp/Dockerfile
+++ b/walkthroughs/howto-k8s-outlier-detection/feapp/Dockerfile
@@ -11,8 +11,11 @@ RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix nocgo -o /aws-app-mesh-examples-feapp .
 
-FROM amazonlinux:2
-RUN yum install -y ca-certificates
+FROM public.ecr.aws/amazonlinux/amazonlinux:2
+RUN yum update -y && \
+    yum install -y ca-certificates && \
+    yum clean all && \
+    rm -rf /var/cache/yum
 COPY --from=builder /aws-app-mesh-examples-feapp bin/aws-app-mesh-examples-feapp
 
 ENTRYPOINT ["/bin/aws-app-mesh-examples-feapp"]

--- a/walkthroughs/howto-match-and-rewrite-at-ingress/src/colorteller/Dockerfile
+++ b/walkthroughs/howto-match-and-rewrite-at-ingress/src/colorteller/Dockerfile
@@ -17,8 +17,11 @@ RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix nocgo -o /src/colorteller .
 
-FROM amazonlinux:2
-RUN yum install -y ca-certificates
+FROM public.ecr.aws/amazonlinux/amazonlinux:2
+RUN yum update -y && \
+    yum install -y ca-certificates && \
+    yum clean all && \
+    rm -rf /var/cache/yum
 COPY --from=builder /src/colorteller /src/colorteller
 
 ENTRYPOINT ["/src/colorteller"]

--- a/walkthroughs/howto-outlier-detection/src/color-app/Dockerfile
+++ b/walkthroughs/howto-outlier-detection/src/color-app/Dockerfile
@@ -17,8 +17,11 @@ RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix nocgo -o /color-app .
 
-FROM amazonlinux:2
-RUN yum install -y ca-certificates
+FROM public.ecr.aws/amazonlinux/amazonlinux:2
+RUN yum update -y && \
+    yum install -y ca-certificates && \
+    yum clean all && \
+    rm -rf /var/cache/yum
 COPY --from=builder /color-app bin/color-app
 
 ENTRYPOINT ["bin/color-app"]

--- a/walkthroughs/howto-outlier-detection/src/frontend-app/Dockerfile
+++ b/walkthroughs/howto-outlier-detection/src/frontend-app/Dockerfile
@@ -16,8 +16,11 @@ RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix nocgo -o /frontend-app .
 
-FROM amazonlinux:2
-RUN yum install -y ca-certificates
+FROM public.ecr.aws/amazonlinux/amazonlinux:2
+RUN yum update -y && \
+    yum install -y ca-certificates && \
+    yum clean all && \
+    rm -rf /var/cache/yum
 COPY --from=builder /frontend-app bin/frontend-app
 
 ENTRYPOINT ["bin/frontend-app"]


### PR DESCRIPTION
Modify all the Dockerfile wholesale to reduce the image size
- Not a functional change, just refactoring
- Change pulling al2 from dockerhub to ECR public
- add clean up command on the same layer, which will reduce the docker image size created almost by half
- Build from scratch is not done, as this is bigger effort



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
