### PR TITLE
Use xray daemon from ecr public repo instead of dockerhub

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ examples/apps/colorapp/pkg/
 examples/apps/colorapp/bin
 .DS_Store
 .idea
+.vscode

--- a/blogs/ecs-cross-account/account_backend/redis_and_database.yml
+++ b/blogs/ecs-cross-account/account_backend/redis_and_database.yml
@@ -142,7 +142,7 @@ Resources:
             - ContainerPort: 5432
               Protocol: "tcp"
         - Name: xray-daemon
-          Image: amazon/aws-xray-daemon
+          Image: public.ecr.aws/xray/aws-xray-daemon
           Essential: true
           User: "1337"
           PortMappings:
@@ -270,7 +270,7 @@ Resources:
             - ContainerPort: 6379
               Protocol: "tcp"
         - Name: xray-daemon
-          Image: amazon/aws-xray-daemon
+          Image: public.ecr.aws/xray/aws-xray-daemon
           Essential: true
           User: "1337"
           PortMappings:

--- a/blogs/ecs-cross-account/account_frontend/app_and_frontend.yml
+++ b/blogs/ecs-cross-account/account_frontend/app_and_frontend.yml
@@ -220,7 +220,7 @@ Resources:
             - ContainerPort: 4567
               Protocol: "tcp"
         - Name: xray-daemon
-          Image: amazon/aws-xray-daemon
+          Image: public.ecr.aws/xray/aws-xray-daemon
           Essential: true
           User: "1337"
           PortMappings:
@@ -351,7 +351,7 @@ Resources:
             - ContainerPort: 80
               Protocol: "tcp"
         - Name: xray-daemon
-          Image: amazon/aws-xray-daemon
+          Image: public.ecr.aws/xray/aws-xray-daemon
           Essential: true
           User: "1337"
           PortMappings:

--- a/blogs/ecs-service-connectivity/yelb/deployments/platformdeployment/AWS/ECS/yelb-cloudformation-ECS-AppMesh-deployment.yaml
+++ b/blogs/ecs-service-connectivity/yelb/deployments/platformdeployment/AWS/ECS/yelb-cloudformation-ECS-AppMesh-deployment.yaml
@@ -158,7 +158,7 @@ Resources:
                       - ContainerName: envoy
                         Condition: HEALTHY
                 - Name: xray
-                  Image: amazon/aws-xray-daemon
+                  Image: public.ecr.aws/xray/aws-xray-daemon
                   Essential: true
                   User: '1337'
                   LogConfiguration:
@@ -377,7 +377,7 @@ Resources:
                       - ContainerName: envoy
                         Condition: HEALTHY
                 - Name: xray
-                  Image: amazon/aws-xray-daemon
+                  Image: public.ecr.aws/xray/aws-xray-daemon
                   Essential: true
                   User: '1337'
                   LogConfiguration:

--- a/examples/apps/colorapp/ecs/xray-container.json
+++ b/examples/apps/colorapp/ecs/xray-container.json
@@ -1,6 +1,6 @@
 {
   "name": "xray-daemon",
-  "image": "amazon/aws-xray-daemon",
+  "image": "public.ecr.aws/xray/aws-xray-daemon",
   "user": "1337",
   "essential": true,
   "cpu": 32,

--- a/walkthroughs/fargate/xray-container.json
+++ b/walkthroughs/fargate/xray-container.json
@@ -1,6 +1,6 @@
 {
   "name": "xray-daemon",
-  "image": "amazon/aws-xray-daemon",
+  "image": "public.ecr.aws/xray/aws-xray-daemon",
   "user": "1337",
   "essential": true,
   "cpu": 32,

--- a/walkthroughs/howto-alb/app.yaml
+++ b/walkthroughs/howto-alb/app.yaml
@@ -201,7 +201,7 @@ Resources:
                     - '/'
                     - !GetAtt 'BackendV1VirtualNode.VirtualNodeName'
         - Name: 'xray'
-          Image: "amazon/aws-xray-daemon"
+          Image: "public.ecr.aws/xray/aws-xray-daemon"
           Essential: true
           User: '1337'
           LogConfiguration:
@@ -303,7 +303,7 @@ Resources:
                     - '/'
                     - !GetAtt 'BackendV2VirtualNode.VirtualNodeName'
         - Name: 'xray'
-          Image: "amazon/aws-xray-daemon"
+          Image: "public.ecr.aws/xray/aws-xray-daemon"
           Essential: true
           User: '1337'
           LogConfiguration:
@@ -642,7 +642,7 @@ Resources:
                     - '/'
                     - !GetAtt 'FrontVirtualNode.VirtualNodeName'
         - Name: 'xray'
-          Image: "amazon/aws-xray-daemon"
+          Image: "public.ecr.aws/xray/aws-xray-daemon"
           Essential: true
           User: '1337'
           LogConfiguration:

--- a/walkthroughs/howto-ecs-basics/deploy/0-prelude.yaml
+++ b/walkthroughs/howto-ecs-basics/deploy/0-prelude.yaml
@@ -355,7 +355,7 @@ Resources:
             - Name: XRAY_APP_NAME
               Value: 'color-green'
         - Name: 'xray'
-          Image: "amazon/aws-xray-daemon"
+          Image: "public.ecr.aws/xray/aws-xray-daemon"
           Essential: true
           User: '1337'
           LogConfiguration:
@@ -457,7 +457,7 @@ Resources:
             - Name: XRAY_APP_NAME
               Value: 'front'
         - Name: 'xray'
-          Image: "amazon/aws-xray-daemon"
+          Image: "public.ecr.aws/xray/aws-xray-daemon"
           Essential: true
           User: '1337'
           LogConfiguration:

--- a/walkthroughs/howto-ecs-basics/deploy/1-servicediscovery.yaml
+++ b/walkthroughs/howto-ecs-basics/deploy/1-servicediscovery.yaml
@@ -315,7 +315,7 @@ Resources:
             - Name: XRAY_APP_NAME
               Value: 'color'
         - Name: 'xray'
-          Image: "amazon/aws-xray-daemon"
+          Image: "public.ecr.aws/xray/aws-xray-daemon"
           Essential: true
           User: '1337'
           LogConfiguration:
@@ -416,7 +416,7 @@ Resources:
             - Name: XRAY_APP_NAME
               Value: 'front'
         - Name: 'xray'
-          Image: "amazon/aws-xray-daemon"
+          Image: "public.ecr.aws/xray/aws-xray-daemon"
           Essential: true
           User: '1337'
           LogConfiguration:

--- a/walkthroughs/howto-ecs-basics/deploy/2-meshify.yaml
+++ b/walkthroughs/howto-ecs-basics/deploy/2-meshify.yaml
@@ -372,7 +372,7 @@ Resources:
             - Name: XRAY_APP_NAME
               Value: 'color'
         - Name: 'xray'
-          Image: "amazon/aws-xray-daemon"
+          Image: "public.ecr.aws/xray/aws-xray-daemon"
           Essential: true
           User: '1337'
           LogConfiguration:
@@ -606,7 +606,7 @@ Resources:
             - Name: XRAY_APP_NAME
               Value: 'front'
         - Name: 'xray'
-          Image: "amazon/aws-xray-daemon"
+          Image: "public.ecr.aws/xray/aws-xray-daemon"
           Essential: true
           User: '1337'
           LogConfiguration:

--- a/walkthroughs/howto-ecs-basics/deploy/3-routing.yaml
+++ b/walkthroughs/howto-ecs-basics/deploy/3-routing.yaml
@@ -372,7 +372,7 @@ Resources:
             - Name: XRAY_APP_NAME
               Value: 'color'
         - Name: 'xray'
-          Image: "amazon/aws-xray-daemon"
+          Image: "public.ecr.aws/xray/aws-xray-daemon"
           Essential: true
           User: '1337'
           LogConfiguration:
@@ -547,7 +547,7 @@ Resources:
             - Name: XRAY_APP_NAME
               Value: 'color-v2'
         - Name: 'xray'
-          Image: "amazon/aws-xray-daemon"
+          Image: "public.ecr.aws/xray/aws-xray-daemon"
           Essential: true
           User: '1337'
           LogConfiguration:
@@ -809,7 +809,7 @@ Resources:
             - Name: XRAY_APP_NAME
               Value: 'front'
         - Name: 'xray'
-          Image: "amazon/aws-xray-daemon"
+          Image: "public.ecr.aws/xray/aws-xray-daemon"
           Essential: true
           User: '1337'
           LogConfiguration:


### PR DESCRIPTION
**Description of changes:**

Changed bunch of cloudformation and other config files to pull X-Ray daemon image from ECR public repo instead of Dockerhub.

amazon/aws-xray-daemon latest image on Dockerhub is 62MB [link](https://hub.docker.com/r/amazon/aws-xray-daemon/tags?page=1&ordering=last_updated)

xray/aws-xray-daemon on ECR public repo built from scratch is 3.51MB [link](https://gallery.ecr.aws/xray/aws-xray-daemon)


No functional change here. I tested that we can use the xray daemon from ECR public repo by running howto-ecs-basics walkthrough.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
