### PR TITLE
Need python3 to install awccli from awscli-bundle

### DIFF
--- a/walkthroughs/howto-mutual-tls-file-provided-by-acm/src/customEnvoyImage/Dockerfile
+++ b/walkthroughs/howto-mutual-tls-file-provided-by-acm/src/customEnvoyImage/Dockerfile
@@ -1,11 +1,16 @@
 ARG ENVOY_IMAGE
 FROM ${ENVOY_IMAGE}
 
-RUN yum install -y jq curl unzip openssl && \
+RUN yum update -y && \
+    yum install -y python3 jq curl unzip openssl && \
     curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip" && \
     unzip awscli-bundle.zip && \
+    sed -i "s/env python/env python3/g" ./awscli-bundle/install && \
     ./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws && \
-    rm -rf awscli-bundle.zip ./awscli-bundle
+    rm -rf awscli-bundle.zip ./awscli-bundle && \
+    yum remove -y python3 unzip && \
+    yum clean all && \
+    rm -rf /var/cache/yum
 
 RUN mkdir /keys && chown 1337:1337 /keys 
 

--- a/walkthroughs/howto-mutual-tls-file-provided/src/customEnvoyImage/Dockerfile
+++ b/walkthroughs/howto-mutual-tls-file-provided/src/customEnvoyImage/Dockerfile
@@ -1,11 +1,16 @@
 ARG ENVOY_IMAGE
 FROM ${ENVOY_IMAGE}
 
-RUN yum install -y jq curl unzip && \
+RUN yum update -y && \
+    yum install -y python3 jq curl unzip openssl && \
     curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip" && \
     unzip awscli-bundle.zip && \
+    sed -i "s/env python/env python3/g" ./awscli-bundle/install && \
     ./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws && \
-    rm -rf awscli-bundle.zip ./awscli-bundle
+    rm -rf awscli-bundle.zip ./awscli-bundle && \
+    yum remove -y python3 unzip && \
+    yum clean all && \
+    rm -rf /var/cache/yum
 
 RUN mkdir /keys && chown 1337:1337 /keys 
 

--- a/walkthroughs/howto-tls-file-provided/src/customEnvoyImage/Dockerfile
+++ b/walkthroughs/howto-tls-file-provided/src/customEnvoyImage/Dockerfile
@@ -1,11 +1,16 @@
 ARG ENVOY_IMAGE
 FROM ${ENVOY_IMAGE}
 
-RUN yum install -y jq curl unzip && \
+RUN yum update -y && \
+    yum install -y python3 jq curl unzip && \
     curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip" && \
     unzip awscli-bundle.zip && \
+    sed -i "s/env python/env python3/g" ./awscli-bundle/install && \
     ./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws && \
-    rm -rf awscli-bundle.zip ./awscli-bundle
+    rm -rf awscli-bundle.zip ./awscli-bundle && \
+    yum remove -y python3 unzip && \
+    yum clean all && \
+    rm -rf /var/cache/yum
 
 RUN mkdir /keys && chown 1337:1337 /keys 
 


### PR DESCRIPTION
**Description of changes:**

Modify the Dockerfile which generate customEnvoyImage to use python3 to install `awscli` else we run into this following error

```
Unsupported Python version detected: Python 2.7
To continue using this installer you must use Python 3.6 or later.
For more information see the following blog post: https://aws.amazon.com/blogs/developer/announcing-end-of-support-for-python-2-7-in-aws-sdk-for-python-and-aws-cli-v1/
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
