### PR TITLE
Update golang dockerfile to move away from dockerhub

### DIFF
--- a/examples/apps/colorapp/src/colorteller/Dockerfile
+++ b/examples/apps/colorapp/src/colorteller/Dockerfile
@@ -1,9 +1,19 @@
-FROM golang:1-stretch as builder
+FROM public.ecr.aws/amazonlinux/amazonlinux:2 AS builder
+RUN yum update -y && \
+    yum install -y ca-certificates unzip tar gzip git && \
+    yum clean all && \
+    rm -rf /var/cache/yum
+
+RUN curl -LO https://golang.org/dl/go1.17.1.linux-amd64.tar.gz && \
+    tar -C /usr/local -xzvf go1.17.1.linux-amd64.tar.gz
+
+ENV PATH="${PATH}:/usr/local/go/bin"
+ENV GOPATH="${HOME}/go"
+ENV PATH="${PATH}:${GOPATH}/bin"
+
 ARG GO_PROXY=https://proxy.golang.org
 WORKDIR /go/src/github.com/aws/aws-app-mesh-examples/colorapp/teller
 
-# Force the go compiler to use modules.
-ENV GO111MODULE=on
 # go.mod and go.sum go into their own layers.
 COPY go.mod .
 COPY go.sum .

--- a/examples/apps/colorapp/src/gateway/Dockerfile
+++ b/examples/apps/colorapp/src/gateway/Dockerfile
@@ -1,9 +1,18 @@
-FROM golang:1-stretch as builder
+FROM public.ecr.aws/amazonlinux/amazonlinux:2 AS builder
+RUN yum update -y && \
+    yum install -y ca-certificates unzip tar gzip git && \
+    yum clean all && \
+    rm -rf /var/cache/yum
+
+RUN curl -LO https://golang.org/dl/go1.17.1.linux-amd64.tar.gz && \
+    tar -C /usr/local -xzvf go1.17.1.linux-amd64.tar.gz
+
+ENV PATH="${PATH}:/usr/local/go/bin"
+ENV GOPATH="${HOME}/go"
+ENV PATH="${PATH}:${GOPATH}/bin"
+
 ARG GO_PROXY=https://proxy.golang.org
 WORKDIR /go/src/github.com/aws/aws-app-mesh-examples/colorapp/gateway
-
-# Force the go compiler to use modules.
-ENV GO111MODULE=on
 
 # go.mod and go.sum go into their own layers.
 COPY go.mod .

--- a/walkthroughs/howto-circuit-breakers/src/colorteller/Dockerfile
+++ b/walkthroughs/howto-circuit-breakers/src/colorteller/Dockerfile
@@ -1,4 +1,15 @@
-FROM golang:1 AS builder
+FROM public.ecr.aws/amazonlinux/amazonlinux:2 AS builder
+RUN yum update -y && \
+    yum install -y ca-certificates unzip tar gzip git && \
+    yum clean all && \
+    rm -rf /var/cache/yum
+
+RUN curl -LO https://golang.org/dl/go1.17.1.linux-amd64.tar.gz && \
+    tar -C /usr/local -xzvf go1.17.1.linux-amd64.tar.gz
+
+ENV PATH="${PATH}:/usr/local/go/bin"
+ENV GOPATH="${HOME}/go"
+ENV PATH="${PATH}:${GOPATH}/bin"
 
 # Use the default go proxy
 ARG GO_PROXY=https://proxy.golang.org

--- a/walkthroughs/howto-grpc-ingress-gateway/color_server/Dockerfile
+++ b/walkthroughs/howto-grpc-ingress-gateway/color_server/Dockerfile
@@ -1,4 +1,15 @@
-FROM golang:1 AS builder
+FROM public.ecr.aws/amazonlinux/amazonlinux:2 AS builder
+RUN yum update -y && \
+    yum install -y ca-certificates unzip tar gzip git && \
+    yum clean all && \
+    rm -rf /var/cache/yum
+
+RUN curl -LO https://golang.org/dl/go1.17.1.linux-amd64.tar.gz && \
+    tar -C /usr/local -xzvf go1.17.1.linux-amd64.tar.gz
+
+ENV PATH="${PATH}:/usr/local/go/bin"
+ENV GOPATH="${HOME}/go"
+ENV PATH="${PATH}:${GOPATH}/bin"
 
 # Use the default go proxy
 ARG GO_PROXY=https://proxy.golang.org

--- a/walkthroughs/howto-grpc/color_client/Dockerfile
+++ b/walkthroughs/howto-grpc/color_client/Dockerfile
@@ -1,4 +1,15 @@
-FROM golang:1 AS builder
+FROM public.ecr.aws/amazonlinux/amazonlinux:2 AS builder
+RUN yum update -y && \
+    yum install -y ca-certificates unzip tar gzip git && \
+    yum clean all && \
+    rm -rf /var/cache/yum
+
+RUN curl -LO https://golang.org/dl/go1.17.1.linux-amd64.tar.gz && \
+    tar -C /usr/local -xzvf go1.17.1.linux-amd64.tar.gz
+
+ENV PATH="${PATH}:/usr/local/go/bin"
+ENV GOPATH="${HOME}/go"
+ENV PATH="${PATH}:${GOPATH}/bin"
 
 # Use the default go proxy
 ARG GO_PROXY=https://proxy.golang.org

--- a/walkthroughs/howto-grpc/color_server/Dockerfile
+++ b/walkthroughs/howto-grpc/color_server/Dockerfile
@@ -1,4 +1,15 @@
-FROM golang:1 AS builder
+FROM public.ecr.aws/amazonlinux/amazonlinux:2 AS builder
+RUN yum update -y && \
+    yum install -y ca-certificates unzip tar gzip git && \
+    yum clean all && \
+    rm -rf /var/cache/yum
+
+RUN curl -LO https://golang.org/dl/go1.17.1.linux-amd64.tar.gz && \
+    tar -C /usr/local -xzvf go1.17.1.linux-amd64.tar.gz
+
+ENV PATH="${PATH}:/usr/local/go/bin"
+ENV GOPATH="${HOME}/go"
+ENV PATH="${PATH}:${GOPATH}/bin"
 
 # Use the default go proxy
 ARG GO_PROXY=https://proxy.golang.org

--- a/walkthroughs/howto-http2/color_client/Dockerfile
+++ b/walkthroughs/howto-http2/color_client/Dockerfile
@@ -1,4 +1,15 @@
-FROM golang:1 AS builder
+FROM public.ecr.aws/amazonlinux/amazonlinux:2 AS builder
+RUN yum update -y && \
+    yum install -y ca-certificates unzip tar gzip git && \
+    yum clean all && \
+    rm -rf /var/cache/yum
+
+RUN curl -LO https://golang.org/dl/go1.17.1.linux-amd64.tar.gz && \
+    tar -C /usr/local -xzvf go1.17.1.linux-amd64.tar.gz
+
+ENV PATH="${PATH}:/usr/local/go/bin"
+ENV GOPATH="${HOME}/go"
+ENV PATH="${PATH}:${GOPATH}/bin"
 
 # Use the default go proxy
 ARG GO_PROXY=https://proxy.golang.org

--- a/walkthroughs/howto-http2/color_server/Dockerfile
+++ b/walkthroughs/howto-http2/color_server/Dockerfile
@@ -1,4 +1,15 @@
-FROM golang:1 AS builder
+FROM public.ecr.aws/amazonlinux/amazonlinux:2 AS builder
+RUN yum update -y && \
+    yum install -y ca-certificates unzip tar gzip git && \
+    yum clean all && \
+    rm -rf /var/cache/yum
+
+RUN curl -LO https://golang.org/dl/go1.17.1.linux-amd64.tar.gz && \
+    tar -C /usr/local -xzvf go1.17.1.linux-amd64.tar.gz
+
+ENV PATH="${PATH}:/usr/local/go/bin"
+ENV GOPATH="${HOME}/go"
+ENV PATH="${PATH}:${GOPATH}/bin"
 
 # Use the default go proxy
 ARG GO_PROXY=https://proxy.golang.org

--- a/walkthroughs/howto-ingress-gateway/src/colorteller/Dockerfile
+++ b/walkthroughs/howto-ingress-gateway/src/colorteller/Dockerfile
@@ -1,21 +1,26 @@
-FROM golang:1-stretch AS builder
+FROM public.ecr.aws/amazonlinux/amazonlinux:2 AS builder
+RUN yum update -y && \
+    yum install -y ca-certificates unzip tar gzip git && \
+    yum clean all && \
+    rm -rf /var/cache/yum
 
-# Download and install the latest release of dep
-ADD https://github.com/golang/dep/releases/download/v0.4.1/dep-linux-amd64 /usr/bin/dep
-RUN chmod +x /usr/bin/dep
+RUN curl -LO https://golang.org/dl/go1.17.1.linux-amd64.tar.gz && \
+    tar -C /usr/local -xzvf go1.17.1.linux-amd64.tar.gz
+
+ENV PATH="${PATH}:/usr/local/go/bin"
+ENV GOPATH="${HOME}/go"
+ENV PATH="${PATH}:${GOPATH}/bin"
 
 # Copy the code from the host and compile it
 WORKDIR $GOPATH/src/github.com/username/repo
 COPY Gopkg.toml Gopkg.lock ./
-RUN dep ensure --vendor-only
 COPY . ./
 
 # Use the default go proxy
 ARG GO_PROXY=https://proxy.golang.org
 ENV GOPROXY=$GO_PROXY
-RUN go mod download
-
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix nocgo -o /app .
+RUN go mod tidy
+RUN CGO_ENABLED=0 GOOS=linux go build -mod=readonly -a -installsuffix nocgo -o /app .
 
 FROM scratch
 COPY --from=builder /app ./

--- a/walkthroughs/howto-ingress-gateway/src/colorteller/go.mod
+++ b/walkthroughs/howto-ingress-gateway/src/colorteller/go.mod
@@ -1,11 +1,11 @@
-module github.com/aws/aws-app-mesh-examples/walkthroughs/tls-with-acm/src/colorteller
+module github.com/aws/aws-app-mesh-examples/walkthroughs/howto-ingress-gateway/src/colorteller
 
-go 1.13
+go 1.17
 
 require (
-	github.com/aws/aws-sdk-go v1.19.0
-	github.com/aws/aws-xray-sdk-go v0.9.4
-	github.com/cihub/seelog v0.0.0-20151216151435-d2c6e5aa9fbf
-	github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af
-	github.com/pkg/errors v0.8.1
+	github.com/DATA-DOG/go-sqlmock v1.5.0 // indirect
+	github.com/aws/aws-sdk-go v1.19.0 // indirect
+	github.com/aws/aws-xray-sdk-go v1.6.0
+	github.com/stretchr/testify v1.7.0 // indirect
+	golang.org/x/net v0.0.0-20210929193557-e81a3d93ecf6 // indirect
 )

--- a/walkthroughs/howto-k8s-connection-pools/colorapp/Dockerfile
+++ b/walkthroughs/howto-k8s-connection-pools/colorapp/Dockerfile
@@ -1,4 +1,15 @@
-FROM golang:1 AS builder
+FROM public.ecr.aws/amazonlinux/amazonlinux:2 AS builder
+RUN yum update -y && \
+    yum install -y ca-certificates unzip tar gzip git && \
+    yum clean all && \
+    rm -rf /var/cache/yum
+
+RUN curl -LO https://golang.org/dl/go1.17.1.linux-amd64.tar.gz && \
+    tar -C /usr/local -xzvf go1.17.1.linux-amd64.tar.gz
+
+ENV PATH="${PATH}:/usr/local/go/bin"
+ENV GOPATH="${HOME}/go"
+ENV PATH="${PATH}:${GOPATH}/bin"
 
 WORKDIR /go/src/github.com/aws/aws-app-mesh-examples/colorapp
 

--- a/walkthroughs/howto-k8s-fargate/src/colorapp/Dockerfile
+++ b/walkthroughs/howto-k8s-fargate/src/colorapp/Dockerfile
@@ -1,9 +1,19 @@
-FROM golang:1-stretch as builder
+FROM public.ecr.aws/amazonlinux/amazonlinux:2 AS builder
+RUN yum update -y && \
+    yum install -y ca-certificates unzip tar gzip git && \
+    yum clean all && \
+    rm -rf /var/cache/yum
+
+RUN curl -LO https://golang.org/dl/go1.17.1.linux-amd64.tar.gz && \
+    tar -C /usr/local -xzvf go1.17.1.linux-amd64.tar.gz
+
+ENV PATH="${PATH}:/usr/local/go/bin"
+ENV GOPATH="${HOME}/go"
+ENV PATH="${PATH}:${GOPATH}/bin"
+
 ARG GOPROXY=https://proxy.golang.org
 WORKDIR /go/src/github.com/aws/aws-app-mesh-examples/colorapp
 
-# Force the go compiler to use modules.
-ENV GO111MODULE=on
 # go.mod and go.sum go into their own layers.
 COPY go.mod .
 COPY go.sum .

--- a/walkthroughs/howto-k8s-fargate/src/feapp/Dockerfile
+++ b/walkthroughs/howto-k8s-fargate/src/feapp/Dockerfile
@@ -1,9 +1,18 @@
-FROM golang:1-stretch as builder
+FROM public.ecr.aws/amazonlinux/amazonlinux:2 AS builder
+RUN yum update -y && \
+    yum install -y ca-certificates unzip tar gzip git && \
+    yum clean all && \
+    rm -rf /var/cache/yum
+
+RUN curl -LO https://golang.org/dl/go1.17.1.linux-amd64.tar.gz && \
+    tar -C /usr/local -xzvf go1.17.1.linux-amd64.tar.gz
+
+ENV PATH="${PATH}:/usr/local/go/bin"
+ENV GOPATH="${HOME}/go"
+ENV PATH="${PATH}:${GOPATH}/bin"
+
 ARG GOPROXY=https://proxy.golang.org
 WORKDIR /go/src/github.com/aws/aws-app-mesh-examples/feapp
-
-# Force the go compiler to use modules.
-ENV GO111MODULE=on
 
 # go.mod and go.sum go into their own layers.
 COPY go.mod .

--- a/walkthroughs/howto-k8s-grpc-ingress-v2/greeter/Dockerfile
+++ b/walkthroughs/howto-k8s-grpc-ingress-v2/greeter/Dockerfile
@@ -1,4 +1,15 @@
-FROM golang:1 AS builder
+FROM public.ecr.aws/amazonlinux/amazonlinux:2 AS builder
+RUN yum update -y && \
+    yum install -y ca-certificates unzip tar gzip git && \
+    yum clean all && \
+    rm -rf /var/cache/yum
+
+RUN curl -LO https://golang.org/dl/go1.17.1.linux-amd64.tar.gz && \
+    tar -C /usr/local -xzvf go1.17.1.linux-amd64.tar.gz
+
+ENV PATH="${PATH}:/usr/local/go/bin"
+ENV GOPATH="${HOME}/go"
+ENV PATH="${PATH}:${GOPATH}/bin"
 
 ARG GO_PROXY=https://proxy.golang.org
 

--- a/walkthroughs/howto-k8s-grpc/color_client/Dockerfile
+++ b/walkthroughs/howto-k8s-grpc/color_client/Dockerfile
@@ -1,4 +1,15 @@
-FROM golang:1 AS builder
+FROM public.ecr.aws/amazonlinux/amazonlinux:2 AS builder
+RUN yum update -y && \
+    yum install -y ca-certificates unzip tar gzip git && \
+    yum clean all && \
+    rm -rf /var/cache/yum
+
+RUN curl -LO https://golang.org/dl/go1.17.1.linux-amd64.tar.gz && \
+    tar -C /usr/local -xzvf go1.17.1.linux-amd64.tar.gz
+
+ENV PATH="${PATH}:/usr/local/go/bin"
+ENV GOPATH="${HOME}/go"
+ENV PATH="${PATH}:${GOPATH}/bin"
 
 # Use the default go proxy
 ARG GO_PROXY=https://proxy.golang.org

--- a/walkthroughs/howto-k8s-grpc/color_server/Dockerfile
+++ b/walkthroughs/howto-k8s-grpc/color_server/Dockerfile
@@ -1,4 +1,15 @@
-FROM golang:1 AS builder
+FROM public.ecr.aws/amazonlinux/amazonlinux:2 AS builder
+RUN yum update -y && \
+    yum install -y ca-certificates unzip tar gzip git && \
+    yum clean all && \
+    rm -rf /var/cache/yum
+
+RUN curl -LO https://golang.org/dl/go1.17.1.linux-amd64.tar.gz && \
+    tar -C /usr/local -xzvf go1.17.1.linux-amd64.tar.gz
+
+ENV PATH="${PATH}:/usr/local/go/bin"
+ENV GOPATH="${HOME}/go"
+ENV PATH="${PATH}:${GOPATH}/bin"
 
 # Use the default go proxy
 ARG GO_PROXY=https://proxy.golang.org

--- a/walkthroughs/howto-k8s-http2/color_client/Dockerfile
+++ b/walkthroughs/howto-k8s-http2/color_client/Dockerfile
@@ -1,4 +1,15 @@
-FROM golang:1 AS builder
+FROM public.ecr.aws/amazonlinux/amazonlinux:2 AS builder
+RUN yum update -y && \
+    yum install -y ca-certificates unzip tar gzip git && \
+    yum clean all && \
+    rm -rf /var/cache/yum
+
+RUN curl -LO https://golang.org/dl/go1.17.1.linux-amd64.tar.gz && \
+    tar -C /usr/local -xzvf go1.17.1.linux-amd64.tar.gz
+
+ENV PATH="${PATH}:/usr/local/go/bin"
+ENV GOPATH="${HOME}/go"
+ENV PATH="${PATH}:${GOPATH}/bin"
 
 # Use the default go proxy
 ARG GO_PROXY=https://proxy.golang.org

--- a/walkthroughs/howto-k8s-http2/color_server/Dockerfile
+++ b/walkthroughs/howto-k8s-http2/color_server/Dockerfile
@@ -1,4 +1,15 @@
-FROM golang:1 AS builder
+FROM public.ecr.aws/amazonlinux/amazonlinux:2 AS builder
+RUN yum update -y && \
+    yum install -y ca-certificates unzip tar gzip git && \
+    yum clean all && \
+    rm -rf /var/cache/yum
+
+RUN curl -LO https://golang.org/dl/go1.17.1.linux-amd64.tar.gz && \
+    tar -C /usr/local -xzvf go1.17.1.linux-amd64.tar.gz
+
+ENV PATH="${PATH}:/usr/local/go/bin"
+ENV GOPATH="${HOME}/go"
+ENV PATH="${PATH}:${GOPATH}/bin"
 
 # Use the default go proxy
 ARG GO_PROXY=https://proxy.golang.org

--- a/walkthroughs/howto-k8s-outlier-detection/colorapp/Dockerfile
+++ b/walkthroughs/howto-k8s-outlier-detection/colorapp/Dockerfile
@@ -1,4 +1,15 @@
-FROM golang:1 AS builder
+FROM public.ecr.aws/amazonlinux/amazonlinux:2 AS builder
+RUN yum update -y && \
+    yum install -y ca-certificates unzip tar gzip git && \
+    yum clean all && \
+    rm -rf /var/cache/yum
+
+RUN curl -LO https://golang.org/dl/go1.17.1.linux-amd64.tar.gz && \
+    tar -C /usr/local -xzvf go1.17.1.linux-amd64.tar.gz
+
+ENV PATH="${PATH}:/usr/local/go/bin"
+ENV GOPATH="${HOME}/go"
+ENV PATH="${PATH}:${GOPATH}/bin"
 
 WORKDIR /go/src/github.com/aws/aws-app-mesh-examples/colorapp
 

--- a/walkthroughs/howto-k8s-outlier-detection/feapp/Dockerfile
+++ b/walkthroughs/howto-k8s-outlier-detection/feapp/Dockerfile
@@ -1,4 +1,15 @@
-FROM golang:1 AS builder
+FROM public.ecr.aws/amazonlinux/amazonlinux:2 AS builder
+RUN yum update -y && \
+    yum install -y ca-certificates unzip tar gzip git && \
+    yum clean all && \
+    rm -rf /var/cache/yum
+
+RUN curl -LO https://golang.org/dl/go1.17.1.linux-amd64.tar.gz && \
+    tar -C /usr/local -xzvf go1.17.1.linux-amd64.tar.gz
+
+ENV PATH="${PATH}:/usr/local/go/bin"
+ENV GOPATH="${HOME}/go"
+ENV PATH="${PATH}:${GOPATH}/bin"
 
 WORKDIR /go/src/github.com/aws/aws-app-mesh-examples/feapp
 

--- a/walkthroughs/howto-match-and-rewrite-at-ingress/src/colorteller/Dockerfile
+++ b/walkthroughs/howto-match-and-rewrite-at-ingress/src/colorteller/Dockerfile
@@ -1,4 +1,15 @@
-FROM golang:1 AS builder
+FROM public.ecr.aws/amazonlinux/amazonlinux:2 AS builder
+RUN yum update -y && \
+    yum install -y ca-certificates unzip tar gzip git && \
+    yum clean all && \
+    rm -rf /var/cache/yum
+
+RUN curl -LO https://golang.org/dl/go1.17.1.linux-amd64.tar.gz && \
+    tar -C /usr/local -xzvf go1.17.1.linux-amd64.tar.gz
+
+ENV PATH="${PATH}:/usr/local/go/bin"
+ENV GOPATH="${HOME}/go"
+ENV PATH="${PATH}:${GOPATH}/bin"
 
 # Use the default go proxy
 ARG GO_PROXY=https://proxy.golang.org

--- a/walkthroughs/howto-mutual-tls-file-provided-by-acm/src/colorteller/Dockerfile
+++ b/walkthroughs/howto-mutual-tls-file-provided-by-acm/src/colorteller/Dockerfile
@@ -1,21 +1,26 @@
-FROM golang:1-stretch AS builder
+FROM public.ecr.aws/amazonlinux/amazonlinux:2 AS builder
+RUN yum update -y && \
+    yum install -y ca-certificates unzip tar gzip git && \
+    yum clean all && \
+    rm -rf /var/cache/yum
 
-# Download and install the latest release of dep
-ADD https://github.com/golang/dep/releases/download/v0.4.1/dep-linux-amd64 /usr/bin/dep
-RUN chmod +x /usr/bin/dep
+RUN curl -LO https://golang.org/dl/go1.17.1.linux-amd64.tar.gz && \
+    tar -C /usr/local -xzvf go1.17.1.linux-amd64.tar.gz
+
+ENV PATH="${PATH}:/usr/local/go/bin"
+ENV GOPATH="${HOME}/go"
+ENV PATH="${PATH}:${GOPATH}/bin"
 
 # Copy the code from the host and compile it
 WORKDIR $GOPATH/src/github.com/username/repo
 COPY Gopkg.toml Gopkg.lock ./
-RUN dep ensure --vendor-only
 COPY . ./
 
 # Use the default go proxy
 ARG GO_PROXY=https://proxy.golang.org
 ENV GOPROXY=$GO_PROXY
-RUN go mod download
-
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix nocgo -o /app .
+RUN go mod tidy
+RUN CGO_ENABLED=0 GOOS=linux go build -mod=readonly -a -installsuffix nocgo -o /app .
 
 FROM scratch
 COPY --from=builder /app ./

--- a/walkthroughs/howto-mutual-tls-file-provided-by-acm/src/colorteller/go.mod
+++ b/walkthroughs/howto-mutual-tls-file-provided-by-acm/src/colorteller/go.mod
@@ -1,11 +1,11 @@
-module github.com/aws/aws-app-mesh-examples/walkthroughs/tls-with-acm/src/colorteller
+module github.com/aws/aws-app-mesh-examples/walkthroughs/howto-mutual-tls-file-provided-by-acm/src/colorteller
 
-go 1.13
+go 1.17
 
 require (
-	github.com/aws/aws-sdk-go v1.19.0
-	github.com/aws/aws-xray-sdk-go v0.9.4
-	github.com/cihub/seelog v0.0.0-20151216151435-d2c6e5aa9fbf
-	github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af
-	github.com/pkg/errors v0.8.1
+	github.com/DATA-DOG/go-sqlmock v1.5.0 // indirect
+	github.com/aws/aws-sdk-go v1.19.0 // indirect
+	github.com/aws/aws-xray-sdk-go v1.6.0
+	github.com/stretchr/testify v1.7.0 // indirect
+	golang.org/x/net v0.0.0-20210929193557-e81a3d93ecf6 // indirect
 )

--- a/walkthroughs/howto-mutual-tls-file-provided/src/colorteller/Dockerfile
+++ b/walkthroughs/howto-mutual-tls-file-provided/src/colorteller/Dockerfile
@@ -1,7 +1,22 @@
-FROM golang:1-buster AS builder
+FROM public.ecr.aws/amazonlinux/amazonlinux:2 AS builder
+RUN yum update -y && \
+    yum install -y ca-certificates unzip tar gzip git && \
+    yum clean all && \
+    rm -rf /var/cache/yum
+
+RUN curl -LO https://golang.org/dl/go1.17.1.linux-amd64.tar.gz && \
+    tar -C /usr/local -xzvf go1.17.1.linux-amd64.tar.gz
+
+ENV PATH="${PATH}:/usr/local/go/bin"
+ENV GOPATH="${HOME}/go"
+ENV PATH="${PATH}:${GOPATH}/bin"
 
 COPY . ./
 
+# Use the default go proxy
+ARG GO_PROXY=https://proxy.golang.org
+ENV GOPROXY=$GO_PROXY
+RUN go mod tidy
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix nocgo -o /app .
 
 FROM scratch

--- a/walkthroughs/howto-outlier-detection/src/color-app/Dockerfile
+++ b/walkthroughs/howto-outlier-detection/src/color-app/Dockerfile
@@ -1,4 +1,15 @@
-FROM golang:1 AS builder
+FROM public.ecr.aws/amazonlinux/amazonlinux:2 AS builder
+RUN yum update -y && \
+    yum install -y ca-certificates unzip tar gzip git && \
+    yum clean all && \
+    rm -rf /var/cache/yum
+
+RUN curl -LO https://golang.org/dl/go1.17.1.linux-amd64.tar.gz && \
+    tar -C /usr/local -xzvf go1.17.1.linux-amd64.tar.gz
+
+ENV PATH="${PATH}:/usr/local/go/bin"
+ENV GOPATH="${HOME}/go"
+ENV PATH="${PATH}:${GOPATH}/bin"
 
 # Use the default go proxy
 ARG GO_PROXY=https://proxy.golang.org

--- a/walkthroughs/howto-outlier-detection/src/frontend-app/Dockerfile
+++ b/walkthroughs/howto-outlier-detection/src/frontend-app/Dockerfile
@@ -1,4 +1,15 @@
-FROM golang:1 AS builder
+FROM public.ecr.aws/amazonlinux/amazonlinux:2 AS builder
+RUN yum update -y && \
+    yum install -y ca-certificates unzip tar gzip git && \
+    yum clean all && \
+    rm -rf /var/cache/yum
+
+RUN curl -LO https://golang.org/dl/go1.17.1.linux-amd64.tar.gz && \
+    tar -C /usr/local -xzvf go1.17.1.linux-amd64.tar.gz
+
+ENV PATH="${PATH}:/usr/local/go/bin"
+ENV GOPATH="${HOME}/go"
+ENV PATH="${PATH}:${GOPATH}/bin"
 
 # Use the default go proxy
 ARG GO_PROXY=https://proxy.golang.org

--- a/walkthroughs/howto-timeout-policy/src/colorgateway/Dockerfile
+++ b/walkthroughs/howto-timeout-policy/src/colorgateway/Dockerfile
@@ -1,21 +1,26 @@
-FROM golang:1-stretch AS builder
+FROM public.ecr.aws/amazonlinux/amazonlinux:2 AS builder
+RUN yum update -y && \
+    yum install -y ca-certificates unzip tar gzip git && \
+    yum clean all && \
+    rm -rf /var/cache/yum
 
-# Download and install the latest release of dep
-ADD https://github.com/golang/dep/releases/download/v0.4.1/dep-linux-amd64 /usr/bin/dep
-RUN chmod +x /usr/bin/dep
+RUN curl -LO https://golang.org/dl/go1.17.1.linux-amd64.tar.gz && \
+    tar -C /usr/local -xzvf go1.17.1.linux-amd64.tar.gz
+
+ENV PATH="${PATH}:/usr/local/go/bin"
+ENV GOPATH="${HOME}/go"
+ENV PATH="${PATH}:${GOPATH}/bin"
 
 # Copy the code from the host and compile it
 WORKDIR $GOPATH/src/github.com/username/repo
 COPY Gopkg.toml Gopkg.lock ./
-RUN dep ensure --vendor-only
 COPY . ./
 
 # Use the default go proxy
 ARG GO_PROXY=https://proxy.golang.org
 ENV GOPROXY=$GO_PROXY
-RUN go mod download
-
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix nocgo -o /app .
+RUN go mod tidy
+RUN CGO_ENABLED=0 GOOS=linux go build -mod=readonly -a -installsuffix nocgo -o /app .
 
 FROM scratch
 COPY --from=builder /app ./

--- a/walkthroughs/howto-timeout-policy/src/colorgateway/go.mod
+++ b/walkthroughs/howto-timeout-policy/src/colorgateway/go.mod
@@ -1,11 +1,11 @@
-module github.com/aws/aws-app-mesh-examples/walkthroughs/tls-with-acm/src/gateway
+module github.com/aws/aws-app-mesh-examples/walkthroughs/howto-timeout-policy/src/colorgateway
 
-go 1.13
+go 1.17
 
 require (
-	github.com/aws/aws-sdk-go v1.19.0
-	github.com/aws/aws-xray-sdk-go v0.9.4
-	github.com/cihub/seelog v0.0.0-20151216151435-d2c6e5aa9fbf
-	github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af
-	github.com/pkg/errors v0.8.0
+	github.com/DATA-DOG/go-sqlmock v1.5.0 // indirect
+	github.com/aws/aws-sdk-go v1.19.0 // indirect
+	github.com/aws/aws-xray-sdk-go v1.6.0
+	github.com/stretchr/testify v1.7.0 // indirect
+	golang.org/x/net v0.0.0-20210929193557-e81a3d93ecf6 // indirect
 )

--- a/walkthroughs/howto-timeout-policy/src/colorteller/Dockerfile
+++ b/walkthroughs/howto-timeout-policy/src/colorteller/Dockerfile
@@ -1,21 +1,26 @@
-FROM golang:1-stretch AS builder
+FROM public.ecr.aws/amazonlinux/amazonlinux:2 AS builder
+RUN yum update -y && \
+    yum install -y ca-certificates unzip tar gzip git && \
+    yum clean all && \
+    rm -rf /var/cache/yum
 
-# Download and install the latest release of dep
-ADD https://github.com/golang/dep/releases/download/v0.4.1/dep-linux-amd64 /usr/bin/dep
-RUN chmod +x /usr/bin/dep
+RUN curl -LO https://golang.org/dl/go1.17.1.linux-amd64.tar.gz && \
+    tar -C /usr/local -xzvf go1.17.1.linux-amd64.tar.gz
+
+ENV PATH="${PATH}:/usr/local/go/bin"
+ENV GOPATH="${HOME}/go"
+ENV PATH="${PATH}:${GOPATH}/bin"
 
 # Copy the code from the host and compile it
 WORKDIR $GOPATH/src/github.com/username/repo
 COPY Gopkg.toml Gopkg.lock ./
-RUN dep ensure --vendor-only
 COPY . ./
 
 # Use the default go proxy
 ARG GO_PROXY=https://proxy.golang.org
 ENV GOPROXY=$GO_PROXY
-RUN go mod download
-
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix nocgo -o /app .
+RUN go mod tidy
+RUN CGO_ENABLED=0 GOOS=linux go build -mod=readonly -a -installsuffix nocgo -o /app .
 
 FROM scratch
 COPY --from=builder /app ./

--- a/walkthroughs/howto-timeout-policy/src/colorteller/go.mod
+++ b/walkthroughs/howto-timeout-policy/src/colorteller/go.mod
@@ -1,11 +1,11 @@
-module github.com/aws/aws-app-mesh-examples/walkthroughs/tls-with-acm/src/colorteller
+module github.com/aws/aws-app-mesh-examples/walkthroughs/howto-timeout-policy/src/colorteller
 
-go 1.13
+go 1.17
 
 require (
-	github.com/aws/aws-sdk-go v1.19.0
-	github.com/aws/aws-xray-sdk-go v0.9.4
-	github.com/cihub/seelog v0.0.0-20151216151435-d2c6e5aa9fbf
-	github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af
-	github.com/pkg/errors v0.8.1
+	github.com/DATA-DOG/go-sqlmock v1.5.0 // indirect
+	github.com/aws/aws-sdk-go v1.19.0 // indirect
+	github.com/aws/aws-xray-sdk-go v1.6.0
+	github.com/stretchr/testify v1.7.0 // indirect
+	golang.org/x/net v0.0.0-20210929193557-e81a3d93ecf6 // indirect
 )

--- a/walkthroughs/howto-tls-file-provided/src/colorteller/Dockerfile
+++ b/walkthroughs/howto-tls-file-provided/src/colorteller/Dockerfile
@@ -1,21 +1,26 @@
-FROM golang:1-stretch AS builder
+FROM public.ecr.aws/amazonlinux/amazonlinux:2 AS builder
+RUN yum update -y && \
+    yum install -y ca-certificates unzip tar gzip git && \
+    yum clean all && \
+    rm -rf /var/cache/yum
 
-# Download and install the latest release of dep
-ADD https://github.com/golang/dep/releases/download/v0.4.1/dep-linux-amd64 /usr/bin/dep
-RUN chmod +x /usr/bin/dep
+RUN curl -LO https://golang.org/dl/go1.17.1.linux-amd64.tar.gz && \
+    tar -C /usr/local -xzvf go1.17.1.linux-amd64.tar.gz
+
+ENV PATH="${PATH}:/usr/local/go/bin"
+ENV GOPATH="${HOME}/go"
+ENV PATH="${PATH}:${GOPATH}/bin"
 
 # Copy the code from the host and compile it
 WORKDIR $GOPATH/src/github.com/username/repo
 COPY Gopkg.toml Gopkg.lock ./
-RUN dep ensure --vendor-only
 COPY . ./
 
 # Use the default go proxy
 ARG GO_PROXY=https://proxy.golang.org
 ENV GOPROXY=$GO_PROXY
-RUN go mod download
-
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix nocgo -o /app .
+RUN go mod tidy
+RUN CGO_ENABLED=0 GOOS=linux go build -mod=readonly -a -installsuffix nocgo -o /app .
 
 FROM scratch
 COPY --from=builder /app ./

--- a/walkthroughs/howto-tls-file-provided/src/colorteller/go.mod
+++ b/walkthroughs/howto-tls-file-provided/src/colorteller/go.mod
@@ -1,11 +1,11 @@
 module github.com/aws/aws-app-mesh-examples/walkthroughs/howto-tls-file-provided/src/colorteller
 
-go 1.13
+go 1.17
 
 require (
-	github.com/aws/aws-sdk-go v1.19.0
-	github.com/aws/aws-xray-sdk-go v0.9.4
-	github.com/cihub/seelog v0.0.0-20151216151435-d2c6e5aa9fbf
-	github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af
-	github.com/pkg/errors v0.8.1
+	github.com/DATA-DOG/go-sqlmock v1.5.0 // indirect
+	github.com/aws/aws-sdk-go v1.19.0 // indirect
+	github.com/aws/aws-xray-sdk-go v1.6.0
+	github.com/stretchr/testify v1.7.0 // indirect
+	golang.org/x/net v0.0.0-20210929193557-e81a3d93ecf6 // indirect
 )

--- a/walkthroughs/tls-with-acm/src/colorteller/Dockerfile
+++ b/walkthroughs/tls-with-acm/src/colorteller/Dockerfile
@@ -1,21 +1,26 @@
-FROM golang:1-stretch AS builder
+FROM public.ecr.aws/amazonlinux/amazonlinux:2 AS builder
+RUN yum update -y && \
+    yum install -y ca-certificates unzip tar gzip git && \
+    yum clean all && \
+    rm -rf /var/cache/yum
 
-# Download and install the latest release of dep
-ADD https://github.com/golang/dep/releases/download/v0.4.1/dep-linux-amd64 /usr/bin/dep
-RUN chmod +x /usr/bin/dep
+RUN curl -LO https://golang.org/dl/go1.17.1.linux-amd64.tar.gz && \
+    tar -C /usr/local -xzvf go1.17.1.linux-amd64.tar.gz
+
+ENV PATH="${PATH}:/usr/local/go/bin"
+ENV GOPATH="${HOME}/go"
+ENV PATH="${PATH}:${GOPATH}/bin"
 
 # Copy the code from the host and compile it
 WORKDIR $GOPATH/src/github.com/username/repo
 COPY Gopkg.toml Gopkg.lock ./
-RUN dep ensure --vendor-only
 COPY . ./
 
 # Use the default go proxy
 ARG GO_PROXY=https://proxy.golang.org
 ENV GOPROXY=$GO_PROXY
-RUN go mod download
-
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix nocgo -o /app .
+RUN go mod tidy
+RUN CGO_ENABLED=0 GOOS=linux go build -mod=readonly -a -installsuffix nocgo -o /app .
 
 FROM scratch
 COPY --from=builder /app ./

--- a/walkthroughs/tls-with-acm/src/colorteller/go.mod
+++ b/walkthroughs/tls-with-acm/src/colorteller/go.mod
@@ -1,11 +1,11 @@
 module github.com/aws/aws-app-mesh-examples/walkthroughs/tls-with-acm/src/colorteller
 
-go 1.13
+go 1.17
 
 require (
-	github.com/aws/aws-sdk-go v1.19.0
-	github.com/aws/aws-xray-sdk-go v0.9.4
-	github.com/cihub/seelog v0.0.0-20151216151435-d2c6e5aa9fbf
-	github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af
-	github.com/pkg/errors v0.8.1
+	github.com/DATA-DOG/go-sqlmock v1.5.0 // indirect
+	github.com/aws/aws-sdk-go v1.19.0 // indirect
+	github.com/aws/aws-xray-sdk-go v1.6.0
+	github.com/stretchr/testify v1.7.0 // indirect
+	golang.org/x/net v0.0.0-20210929193557-e81a3d93ecf6 // indirect
 )


### PR DESCRIPTION
**Description of changes:**
Update golang dockerfile to move away from dockerhub and use ecr public repo instead  
Follow up from #454 & #449


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
