### PR TITLE
Update python dockerfile to move away from dockerhub

### DIFF
--- a/walkthroughs/howto-alb/colorapp/Dockerfile
+++ b/walkthroughs/howto-alb/colorapp/Dockerfile
@@ -1,9 +1,15 @@
-FROM python:alpine
-
-WORKDIR /usr/src/app
+FROM public.ecr.aws/amazonlinux/amazonlinux:2
 
 COPY requirements.txt ./
-RUN pip install --no-cache-dir -r requirements.txt
+
+RUN yum update -y && \
+    yum install -y python3 python3-pip && \
+    pip3 install --no-cache-dir -r requirements.txt && \
+    yum remove -y python3-pip && \
+    yum clean all && \
+    rm -rf /var/cache/yum
+
+WORKDIR /usr/src/app
 
 COPY . .
 

--- a/walkthroughs/howto-alb/feapp/Dockerfile
+++ b/walkthroughs/howto-alb/feapp/Dockerfile
@@ -1,9 +1,15 @@
-FROM python:alpine
-
-WORKDIR /usr/src/app
+FROM public.ecr.aws/amazonlinux/amazonlinux:2
 
 COPY requirements.txt ./
-RUN pip install --no-cache-dir -r requirements.txt
+
+RUN yum update -y && \
+    yum install -y python3 python3-pip && \
+    pip3 install --no-cache-dir -r requirements.txt && \
+    yum remove -y python3-pip && \
+    yum clean all && \
+    rm -rf /var/cache/yum
+
+WORKDIR /usr/src/app
 
 COPY . .
 

--- a/walkthroughs/howto-http-headers/colorapp/Dockerfile
+++ b/walkthroughs/howto-http-headers/colorapp/Dockerfile
@@ -1,4 +1,8 @@
-FROM python:3
+FROM public.ecr.aws/amazonlinux/amazonlinux:2
+RUN yum update -y && \
+    yum install -y python3 && \
+    yum clean all && \
+    rm -rf /var/cache/yum
 
 COPY serve.py ./
 RUN chmod +x ./serve.py

--- a/walkthroughs/howto-http-headers/feapp/Dockerfile
+++ b/walkthroughs/howto-http-headers/feapp/Dockerfile
@@ -1,4 +1,8 @@
-FROM python:3
+FROM public.ecr.aws/amazonlinux/amazonlinux:2
+RUN yum update -y && \
+    yum install -y python3 && \
+    yum clean all && \
+    rm -rf /var/cache/yum
 
 COPY serve.py ./
 RUN chmod +x ./serve.py

--- a/walkthroughs/howto-http-retries/colorapp/Dockerfile
+++ b/walkthroughs/howto-http-retries/colorapp/Dockerfile
@@ -1,4 +1,8 @@
-FROM python:3
+FROM public.ecr.aws/amazonlinux/amazonlinux:2
+RUN yum update -y && \
+    yum install -y python3 && \
+    yum clean all && \
+    rm -rf /var/cache/yum
 
 COPY serve.py ./
 RUN chmod +x ./serve.py

--- a/walkthroughs/howto-http-retries/feapp/Dockerfile
+++ b/walkthroughs/howto-http-retries/feapp/Dockerfile
@@ -1,4 +1,8 @@
-FROM python:3
+FROM public.ecr.aws/amazonlinux/amazonlinux:2
+RUN yum update -y && \
+    yum install -y python3 && \
+    yum clean all && \
+    rm -rf /var/cache/yum
 
 COPY serve.py ./
 RUN chmod +x ./serve.py

--- a/walkthroughs/howto-k8s-alb/colorapp/Dockerfile
+++ b/walkthroughs/howto-k8s-alb/colorapp/Dockerfile
@@ -1,4 +1,8 @@
-FROM python:3
+FROM public.ecr.aws/amazonlinux/amazonlinux:2
+RUN yum update -y && \
+    yum install -y python3 && \
+    yum clean all && \
+    rm -rf /var/cache/yum
 
 COPY serve.py ./
 RUN chmod +x ./serve.py

--- a/walkthroughs/howto-k8s-alb/feapp/Dockerfile
+++ b/walkthroughs/howto-k8s-alb/feapp/Dockerfile
@@ -1,4 +1,8 @@
-FROM python:3
+FROM public.ecr.aws/amazonlinux/amazonlinux:2
+RUN yum update -y && \
+    yum install -y python3 && \
+    yum clean all && \
+    rm -rf /var/cache/yum
 
 COPY serve.py ./
 RUN chmod +x ./serve.py

--- a/walkthroughs/howto-k8s-cloudmap/colorapp/Dockerfile
+++ b/walkthroughs/howto-k8s-cloudmap/colorapp/Dockerfile
@@ -1,9 +1,15 @@
-FROM python:alpine
-
-WORKDIR /usr/src/app
+FROM public.ecr.aws/amazonlinux/amazonlinux:2
 
 COPY requirements.txt ./
-RUN pip install --no-cache-dir -r requirements.txt
+
+RUN yum update -y && \
+    yum install -y python3 python3-pip && \
+    pip3 install --no-cache-dir -r requirements.txt && \
+    yum remove -y python3-pip && \
+    yum clean all && \
+    rm -rf /var/cache/yum
+
+WORKDIR /usr/src/app
 
 COPY . .
 

--- a/walkthroughs/howto-k8s-cloudmap/feapp/Dockerfile
+++ b/walkthroughs/howto-k8s-cloudmap/feapp/Dockerfile
@@ -1,9 +1,15 @@
-FROM python:alpine
-
-WORKDIR /usr/src/app
+FROM public.ecr.aws/amazonlinux/amazonlinux:2
 
 COPY requirements.txt ./
-RUN pip install --no-cache-dir -r requirements.txt
+
+RUN yum update -y && \
+    yum install -y python3 python3-pip && \
+    pip3 install --no-cache-dir -r requirements.txt && \
+    yum remove -y python3-pip && \
+    yum clean all && \
+    rm -rf /var/cache/yum
+
+WORKDIR /usr/src/app
 
 COPY . .
 

--- a/walkthroughs/howto-k8s-cross-cluster/colorapp/Dockerfile
+++ b/walkthroughs/howto-k8s-cross-cluster/colorapp/Dockerfile
@@ -1,9 +1,15 @@
-FROM python:alpine
-
-WORKDIR /usr/src/app
+FROM public.ecr.aws/amazonlinux/amazonlinux:2
 
 COPY requirements.txt ./
-RUN pip install --no-cache-dir -r requirements.txt
+
+RUN yum update -y && \
+    yum install -y python3 python3-pip && \
+    pip3 install --no-cache-dir -r requirements.txt && \
+    yum remove -y python3-pip && \
+    yum clean all && \
+    rm -rf /var/cache/yum
+
+WORKDIR /usr/src/app
 
 COPY . .
 

--- a/walkthroughs/howto-k8s-cross-cluster/feapp/Dockerfile
+++ b/walkthroughs/howto-k8s-cross-cluster/feapp/Dockerfile
@@ -1,9 +1,15 @@
-FROM python:alpine
-
-WORKDIR /usr/src/app
+FROM public.ecr.aws/amazonlinux/amazonlinux:2
 
 COPY requirements.txt ./
-RUN pip install --no-cache-dir -r requirements.txt
+
+RUN yum update -y && \
+    yum install -y python3 python3-pip && \
+    pip3 install --no-cache-dir -r requirements.txt && \
+    yum remove -y python3-pip && \
+    yum clean all && \
+    rm -rf /var/cache/yum
+
+WORKDIR /usr/src/app
 
 COPY . .
 

--- a/walkthroughs/howto-k8s-egress/colorapp/Dockerfile
+++ b/walkthroughs/howto-k8s-egress/colorapp/Dockerfile
@@ -1,4 +1,8 @@
-FROM python:3
+FROM public.ecr.aws/amazonlinux/amazonlinux:2
+RUN yum update -y && \
+    yum install -y python3 && \
+    yum clean all && \
+    rm -rf /var/cache/yum
 
 COPY serve.py ./
 RUN chmod +x ./serve.py

--- a/walkthroughs/howto-k8s-egress/feapp/Dockerfile
+++ b/walkthroughs/howto-k8s-egress/feapp/Dockerfile
@@ -1,4 +1,8 @@
-FROM python:3
+FROM public.ecr.aws/amazonlinux/amazonlinux:2
+RUN yum update -y && \
+    yum install -y python3 && \
+    yum clean all && \
+    rm -rf /var/cache/yum
 
 COPY serve.py ./
 RUN chmod +x ./serve.py

--- a/walkthroughs/howto-k8s-http-headers/colorapp/Dockerfile
+++ b/walkthroughs/howto-k8s-http-headers/colorapp/Dockerfile
@@ -1,4 +1,8 @@
-FROM python:3
+FROM public.ecr.aws/amazonlinux/amazonlinux:2
+RUN yum update -y && \
+    yum install -y python3 && \
+    yum clean all && \
+    rm -rf /var/cache/yum
 
 COPY serve.py ./
 RUN chmod +x ./serve.py

--- a/walkthroughs/howto-k8s-http-headers/feapp/Dockerfile
+++ b/walkthroughs/howto-k8s-http-headers/feapp/Dockerfile
@@ -1,4 +1,8 @@
-FROM python:3
+FROM public.ecr.aws/amazonlinux/amazonlinux:2
+RUN yum update -y && \
+    yum install -y python3 && \
+    yum clean all && \
+    rm -rf /var/cache/yum
 
 COPY serve.py ./
 RUN chmod +x ./serve.py

--- a/walkthroughs/howto-k8s-http-ingress-v2/colorapp/Dockerfile
+++ b/walkthroughs/howto-k8s-http-ingress-v2/colorapp/Dockerfile
@@ -1,4 +1,8 @@
-FROM python:3
+FROM public.ecr.aws/amazonlinux/amazonlinux:2
+RUN yum update -y && \
+    yum install -y python3 && \
+    yum clean all && \
+    rm -rf /var/cache/yum
 
 COPY serve.py ./
 RUN chmod +x ./serve.py

--- a/walkthroughs/howto-k8s-ingress-gateway/colorapp/Dockerfile
+++ b/walkthroughs/howto-k8s-ingress-gateway/colorapp/Dockerfile
@@ -1,4 +1,8 @@
-FROM python:3
+FROM public.ecr.aws/amazonlinux/amazonlinux:2
+RUN yum update -y && \
+    yum install -y python3 && \
+    yum clean all && \
+    rm -rf /var/cache/yum
 
 COPY serve.py ./
 RUN chmod +x ./serve.py

--- a/walkthroughs/howto-k8s-mtls-file-based/colorapp/Dockerfile
+++ b/walkthroughs/howto-k8s-mtls-file-based/colorapp/Dockerfile
@@ -1,4 +1,8 @@
-FROM python:3
+FROM public.ecr.aws/amazonlinux/amazonlinux:2
+RUN yum update -y && \
+    yum install -y python3 && \
+    yum clean all && \
+    rm -rf /var/cache/yum
 
 COPY serve.py ./
 RUN chmod +x ./serve.py

--- a/walkthroughs/howto-k8s-mtls-file-based/feapp/Dockerfile
+++ b/walkthroughs/howto-k8s-mtls-file-based/feapp/Dockerfile
@@ -1,4 +1,8 @@
-FROM python:3
+FROM public.ecr.aws/amazonlinux/amazonlinux:2
+RUN yum update -y && \
+    yum install -y python3 && \
+    yum clean all && \
+    rm -rf /var/cache/yum
 
 COPY serve.py ./
 RUN chmod +x ./serve.py

--- a/walkthroughs/howto-k8s-mtls-sds-based/colorapp/Dockerfile
+++ b/walkthroughs/howto-k8s-mtls-sds-based/colorapp/Dockerfile
@@ -1,4 +1,8 @@
-FROM python:3
+FROM public.ecr.aws/amazonlinux/amazonlinux:2
+RUN yum update -y && \
+    yum install -y python3 && \
+    yum clean all && \
+    rm -rf /var/cache/yum
 
 COPY serve.py ./
 RUN chmod +x ./serve.py

--- a/walkthroughs/howto-k8s-mtls-sds-based/feapp/Dockerfile
+++ b/walkthroughs/howto-k8s-mtls-sds-based/feapp/Dockerfile
@@ -1,4 +1,8 @@
-FROM python:3
+FROM public.ecr.aws/amazonlinux/amazonlinux:2
+RUN yum update -y && \
+    yum install -y python3 && \
+    yum clean all && \
+    rm -rf /var/cache/yum
 
 COPY serve.py ./
 RUN chmod +x ./serve.py

--- a/walkthroughs/howto-k8s-retry-policy/colorapp/Dockerfile
+++ b/walkthroughs/howto-k8s-retry-policy/colorapp/Dockerfile
@@ -1,4 +1,8 @@
-FROM python:3
+FROM public.ecr.aws/amazonlinux/amazonlinux:2
+RUN yum update -y && \
+    yum install -y python3 && \
+    yum clean all && \
+    rm -rf /var/cache/yum
 
 COPY serve.py ./
 RUN chmod +x ./serve.py

--- a/walkthroughs/howto-k8s-retry-policy/feapp/Dockerfile
+++ b/walkthroughs/howto-k8s-retry-policy/feapp/Dockerfile
@@ -1,4 +1,8 @@
-FROM python:3
+FROM public.ecr.aws/amazonlinux/amazonlinux:2
+RUN yum update -y && \
+    yum install -y python3 && \
+    yum clean all && \
+    rm -rf /var/cache/yum
 
 COPY serve.py ./
 RUN chmod +x ./serve.py

--- a/walkthroughs/howto-k8s-timeout-policy/colorapp/Dockerfile
+++ b/walkthroughs/howto-k8s-timeout-policy/colorapp/Dockerfile
@@ -1,9 +1,15 @@
-FROM python:alpine
-
-WORKDIR /usr/src/app
+FROM public.ecr.aws/amazonlinux/amazonlinux:2
 
 COPY requirements.txt ./
-RUN pip install --no-cache-dir -r requirements.txt
+
+RUN yum update -y && \
+    yum install -y python3 python3-pip && \
+    pip3 install --no-cache-dir -r requirements.txt && \
+    yum remove -y python3-pip && \
+    yum clean all && \
+    rm -rf /var/cache/yum
+
+WORKDIR /usr/src/app
 
 COPY . .
 

--- a/walkthroughs/howto-k8s-timeout-policy/feapp/Dockerfile
+++ b/walkthroughs/howto-k8s-timeout-policy/feapp/Dockerfile
@@ -1,9 +1,15 @@
-FROM python:alpine
-
-WORKDIR /usr/src/app
+FROM public.ecr.aws/amazonlinux/amazonlinux:2
 
 COPY requirements.txt ./
-RUN pip install --no-cache-dir -r requirements.txt
+
+RUN yum update -y && \
+    yum install -y python3 python3-pip && \
+    pip3 install --no-cache-dir -r requirements.txt && \
+    yum remove -y python3-pip && \
+    yum clean all && \
+    rm -rf /var/cache/yum
+
+WORKDIR /usr/src/app
 
 COPY . .
 

--- a/walkthroughs/howto-k8s-tls-acm/colorapp/Dockerfile
+++ b/walkthroughs/howto-k8s-tls-acm/colorapp/Dockerfile
@@ -1,4 +1,8 @@
-FROM python:3
+FROM public.ecr.aws/amazonlinux/amazonlinux:2
+RUN yum update -y && \
+    yum install -y python3 && \
+    yum clean all && \
+    rm -rf /var/cache/yum
 
 COPY serve.py ./
 RUN chmod +x ./serve.py

--- a/walkthroughs/howto-k8s-tls-acm/feapp/Dockerfile
+++ b/walkthroughs/howto-k8s-tls-acm/feapp/Dockerfile
@@ -1,4 +1,8 @@
-FROM python:3
+FROM public.ecr.aws/amazonlinux/amazonlinux:2
+RUN yum update -y && \
+    yum install -y python3 && \
+    yum clean all && \
+    rm -rf /var/cache/yum
 
 COPY serve.py ./
 RUN chmod +x ./serve.py

--- a/walkthroughs/howto-k8s-tls-file-based/colorapp/Dockerfile
+++ b/walkthroughs/howto-k8s-tls-file-based/colorapp/Dockerfile
@@ -1,4 +1,8 @@
-FROM python:3
+FROM public.ecr.aws/amazonlinux/amazonlinux:2
+RUN yum update -y && \
+    yum install -y python3 && \
+    yum clean all && \
+    rm -rf /var/cache/yum
 
 COPY serve.py ./
 RUN chmod +x ./serve.py

--- a/walkthroughs/howto-k8s-tls-file-based/feapp/Dockerfile
+++ b/walkthroughs/howto-k8s-tls-file-based/feapp/Dockerfile
@@ -1,4 +1,8 @@
-FROM python:3
+FROM public.ecr.aws/amazonlinux/amazonlinux:2
+RUN yum update -y && \
+    yum install -y python3 && \
+    yum clean all && \
+    rm -rf /var/cache/yum
 
 COPY serve.py ./
 RUN chmod +x ./serve.py


### PR DESCRIPTION
**Description of changes:**
Update python dockerfile to move away from dockerhub and use ecr public repo instead  
Follow up from #454 & #449

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
