### PR TITLE
Don't remove curl which is one of Envoy's External dependencies

### DIFF
--- a/walkthroughs/howto-mutual-tls-file-provided-by-acm/src/customEnvoyImage/Dockerfile
+++ b/walkthroughs/howto-mutual-tls-file-provided-by-acm/src/customEnvoyImage/Dockerfile
@@ -8,7 +8,7 @@ RUN yum update -y && \
     curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
     unzip awscliv2.zip && \
     ./aws/install && \
-    rpm -e --nodeps curl unzip && \
+    rpm -e --nodeps unzip && \
     rm -rf awscliv2.zip ./aws/install && \
     yum clean all && \
     rm -rf /var/cache/yum

--- a/walkthroughs/howto-mutual-tls-file-provided/src/customEnvoyImage/Dockerfile
+++ b/walkthroughs/howto-mutual-tls-file-provided/src/customEnvoyImage/Dockerfile
@@ -8,7 +8,7 @@ RUN yum update -y && \
     curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
     unzip awscliv2.zip && \
     ./aws/install && \
-    rpm -e --nodeps curl unzip && \
+    rpm -e --nodeps unzip && \
     rm -rf awscliv2.zip ./aws/install && \
     yum clean all && \
     rm -rf /var/cache/yum

--- a/walkthroughs/howto-tls-file-provided/src/customEnvoyImage/Dockerfile
+++ b/walkthroughs/howto-tls-file-provided/src/customEnvoyImage/Dockerfile
@@ -8,7 +8,7 @@ RUN yum update -y && \
     curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
     unzip awscliv2.zip && \
     ./aws/install && \
-    rpm -e --nodeps curl unzip && \
+    rpm -e --nodeps unzip && \
     rm -rf awscliv2.zip ./aws/install && \
     yum clean all && \
     rm -rf /var/cache/yum


### PR DESCRIPTION
**Description of changes:**

Don't remove curl which is one of Envoy's External dependencies. [envoy docs](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/security/external_deps.html?highlight=curl)

I was trying to run the walkthrough. I was able to deploy the service and envoy container came up (RUNNING) but the app was not coming up (PENDING), which gave me false confidence about the changes done to customEnvoyImage Dockerfile on last PR https://github.com/aws/aws-app-mesh-examples/pull/455

Now with curl not being removed both the ColorTellerService & ColorGateway comes up without any issue with howto-mutual-tls-file-provided-by-acm example walkthrough.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
