### PR TITLE
Fix: GatewayService creation failed in howto-mutual-tls-file-provided

### DIFF
--- a/walkthroughs/howto-mutual-tls-file-provided/infrastructure/ecs-service.yaml
+++ b/walkthroughs/howto-mutual-tls-file-provided/infrastructure/ecs-service.yaml
@@ -208,6 +208,8 @@ Resources:
 
   GatewayService:
     Type: 'AWS::ECS::Service'
+    DependsOn:
+      - PublicLoadBalancerListener
     Properties:
       Cluster:
         'Fn::ImportValue': !Sub "${EnvironmentName}:ECSCluster"


### PR DESCRIPTION
The `GatewayService` can only be created after `WebTargetGroup` is associated with `PublicLoadBalancer`.
This is done by `PublicLoadBalancerListener` so an explicit dependency is needed here to make Cloudformation wait.

*Description of changes:*

Without this fix, the stack can (sometimes?) fail when it tries to create GatewayService before the load-balancer is ready and the target group is associated with it. I add this error on my first attempt:

```
GatewayService CREATE_FAILED
Invalid request provided: CreateService error: The target group with targetGroupArn
arn:aws:elasticloadbalancing:eu-west-1:ACCOUNT_ID:targetgroup/AppMeshMutualTLSExample-web2/[...]
does not have an associated load balancer
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
