### PR TITLE
Updating the walkthrough instructions

### DIFF
--- a/walkthroughs/eks/o11y-jaeger.md
+++ b/walkthroughs/eks/o11y-jaeger.md
@@ -13,9 +13,9 @@ This guide uses [Colorteller example application with HTTP header bases routing]
 
 App Mesh provides a basic installation to setup Jaeger quickly using Helm. To install the Jaeger pre-configured to work with App Mesh, follow the instructions in [appmesh-jaeger](https://github.com/aws/eks-charts/blob/master/stable/appmesh-jaeger/README.md) Helm charts.
 
-Note: you will need to _restart_ all the running pods inside the mesh after enabling tracing so the Envoy sidecar can pick up the tracing config. Replace the `<name-space>` and `<deployment-name>` with necessary values.
+Note: you will need to _restart_ all the running pods/deployments inside the mesh after enabling tracing so the Envoy sidecar can pick up the tracing config. Replace the `<namespace>` and `<deployment-name>` with necessary values.
 ```sh
-kubectl -n <name-space> rollout restart deployment <deployment-name>
+kubectl -n <namespace> rollout restart deployment <deployment-name>
 ```
 
 #### Option 2: Existing Jaeger deployment

--- a/walkthroughs/eks/o11y-jaeger.md
+++ b/walkthroughs/eks/o11y-jaeger.md
@@ -13,7 +13,10 @@ This guide uses [Colorteller example application with HTTP header bases routing]
 
 App Mesh provides a basic installation to setup Jaeger quickly using Helm. To install the Jaeger pre-configured to work with App Mesh, follow the instructions in [appmesh-jaeger](https://github.com/aws/eks-charts/blob/master/stable/appmesh-jaeger/README.md) Helm charts.
 
-Note: you will need to _restart_ all the running pods inside the mesh after enabling tracing so the Envoy sidecar can pick up the tracing config
+Note: you will need to _restart_ all the running pods inside the mesh after enabling tracing so the Envoy sidecar can pick up the tracing config. Replace the `<name-space>` with your EKS namespace.
+```sh
+kubectl -n <name-space> rollout restart deployment
+```
 
 #### Option 2: Existing Jaeger deployment
 
@@ -25,7 +28,8 @@ helm upgrade -i appmesh-controller eks/appmesh-controller \
     --set tracing.enabled=true \
     --set tracing.provider=jaeger \
     --set tracing.address=<JAEGER_ENDPOINT_ADDR / JAEGER_SERVICE_NAME> \
-    --set tracing.port=<JAEGER_ENDPOINT_PORT>
+    --set tracing.port=<JAEGER_ENDPOINT_PORT> \
+    --set serviceAccount.create=false
 ```
 
 App Mesh configures Envoy sidecars to produce traces in [Zipkin HTTP JSON v2 format](https://www.jaegertracing.io/docs/1.16/apis/#zipkin-formats-stable). The exact tracing config used is:

--- a/walkthroughs/eks/o11y-jaeger.md
+++ b/walkthroughs/eks/o11y-jaeger.md
@@ -13,9 +13,9 @@ This guide uses [Colorteller example application with HTTP header bases routing]
 
 App Mesh provides a basic installation to setup Jaeger quickly using Helm. To install the Jaeger pre-configured to work with App Mesh, follow the instructions in [appmesh-jaeger](https://github.com/aws/eks-charts/blob/master/stable/appmesh-jaeger/README.md) Helm charts.
 
-Note: you will need to _restart_ all the running pods inside the mesh after enabling tracing so the Envoy sidecar can pick up the tracing config. Replace the `<name-space>` with your EKS namespace.
+Note: you will need to _restart_ all the running pods inside the mesh after enabling tracing so the Envoy sidecar can pick up the tracing config. Replace the `<name-space>` and `<deployment-name>` with necessary values.
 ```sh
-kubectl -n <name-space> rollout restart deployment
+kubectl -n <name-space> rollout restart deployment <deployment-name>
 ```
 
 #### Option 2: Existing Jaeger deployment

--- a/walkthroughs/eks/o11y-xray.md
+++ b/walkthroughs/eks/o11y-xray.md
@@ -23,9 +23,9 @@ helm upgrade -i appmesh-controller eks/appmesh-controller \
     --set serviceAccount.create=false
 ```
 
-Note: you will need to _restart_ all the running pods inside the mesh after enabling tracing so the Envoy sidecar can pick up the tracing config. Replace the `<name-space>` and `<deployment-name>` with necessary values.
+Note: you will need to _restart_ all the running pods/deployments inside the mesh after enabling tracing so the Envoy sidecar can pick up the tracing config. Replace the `<namespace>` and `<deployment-name>` with necessary values.
 ```sh
-kubectl -n <name-space> rollout restart deployment <deployment-name>
+kubectl -n <namespace> rollout restart deployment <deployment-name>
 ```
 
 The X-Ray daemon is automatically injected by [App Mesh Controller](https://github.com/aws/aws-app-mesh-controller-for-k8s) into your app containers. Let's verify that with the following command:

--- a/walkthroughs/eks/o11y-xray.md
+++ b/walkthroughs/eks/o11y-xray.md
@@ -19,7 +19,13 @@ Enable X-Ray tracing for the App Mesh data plane
 helm upgrade -i appmesh-controller eks/appmesh-controller \
     --namespace appmesh-system \
     --set tracing.enabled=true \
-    --set tracing.provider=x-ray
+    --set tracing.provider=x-ray \
+    --set serviceAccount.create=false
+```
+
+Note: you will need to _restart_ all the running pods inside the mesh after enabling tracing so the Envoy sidecar can pick up the tracing config. Replace the `<name-space>` with your EKS namespace.
+```sh
+kubectl -n <name-space> rollout restart deployment
 ```
 
 The X-Ray daemon is automatically injected by [App Mesh Controller](https://github.com/aws/aws-app-mesh-controller-for-k8s) into your app containers. Let's verify that with the following command:

--- a/walkthroughs/eks/o11y-xray.md
+++ b/walkthroughs/eks/o11y-xray.md
@@ -23,9 +23,9 @@ helm upgrade -i appmesh-controller eks/appmesh-controller \
     --set serviceAccount.create=false
 ```
 
-Note: you will need to _restart_ all the running pods inside the mesh after enabling tracing so the Envoy sidecar can pick up the tracing config. Replace the `<name-space>` with your EKS namespace.
+Note: you will need to _restart_ all the running pods inside the mesh after enabling tracing so the Envoy sidecar can pick up the tracing config. Replace the `<name-space>` and `<deployment-name>` with necessary values.
 ```sh
-kubectl -n <name-space> rollout restart deployment
+kubectl -n <name-space> rollout restart deployment <deployment-name>
 ```
 
 The X-Ray daemon is automatically injected by [App Mesh Controller](https://github.com/aws/aws-app-mesh-controller-for-k8s) into your app containers. Let's verify that with the following command:


### PR DESCRIPTION
*Issue #, if available:*

- Current X-ray walkthrough instructions doesn't list the to restart the deployment after adding x-ray tracing to the mesh. 
- A walkthrough is supposed to be a simple follow-through, command should be provided to restart the deployment

*Description of changes:*

- Updating the instructions and commands
- AppMesh controller is already installed through base EKS deployment, thus serviceAccount should be set to false by default otherwise error is thrown complaining service account already exists or not created.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
