### PR TITLE
Update v2_app.yaml

### DIFF
--- a/examples/apps/djapp/3_canary_new_version/v2_app.yaml
+++ b/examples/apps/djapp/3_canary_new_version/v2_app.yaml
@@ -114,6 +114,7 @@ spec:
         app: jazz
         version: v2
     spec:
+      serviceAccountName: prod-proxies
       containers:
         - name: jazz
           image: "672518094988.dkr.ecr.us-west-2.amazonaws.com/hello-world:v1.0"
@@ -140,6 +141,7 @@ spec:
         app: metal
         version: v2
     spec:
+      serviceAccountName: prod-proxies
       containers:
         - name: metal
           image: "672518094988.dkr.ecr.us-west-2.amazonaws.com/hello-world:v1.0"


### PR DESCRIPTION
Issue #, if available:

Envoy proxy Pod not starting

Description of changes:

Missing Reference to service account causing Envoy Proxy to get Non-Authorized Error from IAM: Unauthorized to perform appmesh:StreamAggregatedResources

An update its required on the V1 deployment files as well.

Updated reference should also be updated on the Docs of EKS Workshop: https://github.com/aws-samples/eks-workshop/pull/1298

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
