### PR TITLE
Fix broken links in howto-k8s-alb walkthrough

### DIFF
--- a/walkthroughs/howto-k8s-alb/README.md
+++ b/walkthroughs/howto-k8s-alb/README.md
@@ -1,14 +1,14 @@
 ## Overview
-This example shows how to use [ALB Ingress Controller](https://github.com/kubernetes-sigs/aws-alb-ingress-controller) with targets registered as virtual-nodes under App Mesh.
+This example shows how to use [AWS Load Balancer Controller](https://github.com/kubernetes-sigs/aws-load-balancer-controller) with targets registered as virtual-nodes under App Mesh.
 
 ![System Diagram](./howto-k8s-alb.png "System Diagram")
 
 ## Prerequisites
 - [Walkthrough: App Mesh with EKS](../eks/)
-- [Walkthrough: ALB Ingress Controller](https://kubernetes-sigs.github.io/aws-alb-ingress-controller/guide/walkthrough/echoserver/)
+- [Walkthrough: ALB Ingress Controller](https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.3/examples/echo_server/)
 - Install Docker. It is needed to build the demo application images.
 
-Note: Only [deploy the ALB Ingress Controller](https://kubernetes-sigs.github.io/aws-alb-ingress-controller/guide/walkthrough/echoserver/#deploy-the-alb-ingress-controller) and rest this example service will replace the echoserver in the ALB Ingress Controller link provider
+Note: Only [setup the AWS Load Balancer controller](https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.3/examples/echo_server/#setup-the-aws-load-balancer-controller) and rest this example service will replace the echoserver in the ALB Ingress Controller link provider
 
 ## Setup
 

--- a/walkthroughs/howto-k8s-alb/README.md
+++ b/walkthroughs/howto-k8s-alb/README.md
@@ -5,7 +5,7 @@ This example shows how to use [AWS Load Balancer Controller](https://github.com/
 
 ## Prerequisites
 - [Walkthrough: App Mesh with EKS](../eks/)
-- [Walkthrough: ALB Ingress Controller](https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.3/examples/echo_server/)
+- [Walkthrough: AWS Load Balancer Controller](https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.3/examples/echo_server/)
 - Install Docker. It is needed to build the demo application images.
 
 Note: Only [setup the AWS Load Balancer controller](https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.3/examples/echo_server/#setup-the-aws-load-balancer-controller) and rest this example service will replace the echoserver in the ALB Ingress Controller link provider

--- a/walkthroughs/howto-k8s-alb/README.md
+++ b/walkthroughs/howto-k8s-alb/README.md
@@ -31,13 +31,13 @@ Note: Only [setup the AWS Load Balancer controller](https://kubernetes-sigs.gith
 
 Check the events of the ingress to see what has occur.
 
-    ```
+    
     kubectl describe ing -n howto-k8s-alb color
-    ```
+    
 
 You should see similar to the following.
 
-    ```
+    
     Name:             color
     Namespace:        howto-k8s-alb
     Address:          80113f18-howtok8salb-color-0f20-319733316.us-west-2.elb.amazonaws.com
@@ -59,7 +59,7 @@ You should see similar to the following.
       Normal  CREATE  11m    alb-ingress-controller  LoadBalancer 80113f18-howtok8salb-color-0f20 created, ARN: arn:aws:elasticloadbalancing:us-west-2:669977933099:loadbalancer/app/80113f18-howtok8salb-color-0f20/7c45f6fd4eefa871
       Normal  CREATE  11m    alb-ingress-controller  rule 1 created with conditions [{    Field: "path-pattern",    PathPatternConfig: {      Values: ["/"]    }  }]
       Normal  MODIFY  4m12s  alb-ingress-controller  rule 1 modified with conditions [{    Field: "path-pattern",    PathPatternConfig: {      Values: ["/color"]    }  }]
-     ```
+     
 
 To check if the application is reachable via ALB Ingress Controller
 
@@ -87,3 +87,9 @@ You should see similar to the following.
 * Connection #0 to host 80113f18-howtok8salb-color-0f20-319733316.us-west-2.elb.amazonaws.com left intact
 blue
 ```
+
+&nbsp;
+
+## Clean up once done
+
+    kubectl delete ns howto-k8s-alb && kubectl delete mesh howto-k8s-alb

--- a/walkthroughs/howto-k8s-alb/README.md
+++ b/walkthroughs/howto-k8s-alb/README.md
@@ -8,7 +8,7 @@ This example shows how to use [AWS Load Balancer Controller](https://github.com/
 - [Walkthrough: AWS Load Balancer Controller](https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.3/examples/echo_server/)
 - Install Docker. It is needed to build the demo application images.
 
-Note: Only [setup the AWS Load Balancer controller](https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.3/examples/echo_server/#setup-the-aws-load-balancer-controller) and rest this example service will replace the echoserver in the ALB Ingress Controller link provider
+Note: Only [setup the AWS Load Balancer controller](https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.3/examples/echo_server/#setup-the-aws-load-balancer-controller) and rest this example service will replace the echoserver in the AWS Load Balancer Controller link provider
 
 ## Setup
 
@@ -40,52 +40,49 @@ You should see similar to the following.
     
     Name:             color
     Namespace:        howto-k8s-alb
-    Address:          80113f18-howtok8salb-color-0f20-319733316.us-west-2.elb.amazonaws.com
-    Default backend:  default-http-backend:80 (<none>)
+    Address:          k8s-howtok8s-color-63786f35e6-1171992961.us-west-2.elb.amazonaws.com
+    Default backend:  default-http-backend:80 (<error: endpoints "default-http-backend" not found>)
     Rules:
-      Host  Path  Backends
-      ----  ----  --------
-      *
-            /color   color:8080 (192.168.16.27:8080,192.168.59.249:8080)
-    Annotations:
-      kubectl.kubernetes.io/last-applied-configuration:  {"apiVersion":"extensions/v1beta1","kind":"Ingress","metadata":{"annotations":{"alb.ingress.kubernetes.io/healthcheck-path":"/ping","alb.ingress.kubernetes.io/scheme":"internet-facing","alb.ingress.kubernetes.io/target-type":"ip","kubernetes.io/ingress.class":"alb"},"name":"color","namespace":"howto-k8s-alb"},"spec":{"rules":[{"http":{"paths":[{"backend":{"serviceName":"color","servicePort":8080},"path":"/color"}]}}]}}
-      kubernetes.io/ingress.class:                 alb
-      alb.ingress.kubernetes.io/healthcheck-path:  /ping
-      alb.ingress.kubernetes.io/scheme:            internet-facing
-      alb.ingress.kubernetes.io/target-type:       ip
+    Host        Path  Backends
+    ----        ----  --------
+    *           
+                /color   front:8080 ()
+    Annotations:  alb.ingress.kubernetes.io/healthcheck-path: /color
+                alb.ingress.kubernetes.io/scheme: internet-facing
+                alb.ingress.kubernetes.io/target-type: ip
+                kubernetes.io/ingress.class: alb
     Events:
-      Type    Reason  Age    From                    Message
-      ----    ------  ----   ----                    -------
-      Normal  CREATE  11m    alb-ingress-controller  LoadBalancer 80113f18-howtok8salb-color-0f20 created, ARN: arn:aws:elasticloadbalancing:us-west-2:669977933099:loadbalancer/app/80113f18-howtok8salb-color-0f20/7c45f6fd4eefa871
-      Normal  CREATE  11m    alb-ingress-controller  rule 1 created with conditions [{    Field: "path-pattern",    PathPatternConfig: {      Values: ["/"]    }  }]
-      Normal  MODIFY  4m12s  alb-ingress-controller  rule 1 modified with conditions [{    Field: "path-pattern",    PathPatternConfig: {      Values: ["/color"]    }  }]
+    Type    Reason                  Age   From     Message
+    ----    ------                  ----  ----     -------
+    Normal  SuccessfullyReconciled  5s    ingress  Successfully reconciled
      
 
-To check if the application is reachable via ALB Ingress Controller
+To check if the application is reachable via AWS Load Balancer Controller
 
 ```
-curl -v 80113f18-howtok8salb-color-0f20-319733316.us-west-2.elb.amazonaws.com/color
+curl -v k8s-howtok8s-color-63786f35e6-1171992961.us-west-2.elb.amazonaws.com/color
 ```
 
 You should see similar to the following.
 
 ```
-*   Trying 34.208.158.34...
+*   Trying 54.148.15.33...
 * TCP_NODELAY set
-* Connected to 80113f18-howtok8salb-color-0f20-319733316.us-west-2.elb.amazonaws.com (34.208.158.34) port 80 (#0)
-> GET /color HTTP/1.1> Host: 80113f18-howtok8salb-color-0f20-319733316.us-west-2.elb.amazonaws.com
-> User-Agent: curl/7.61.1
+* Connected to k8s-howtok8s-color-63786f35e6-1171992961.us-west-2.elb.amazonaws.com (54.148.15.33) port 80 (#0)
+> GET /color HTTP/1.1
+> Host: k8s-howtok8s-color-63786f35e6-1171992961.us-west-2.elb.amazonaws.com
+> User-Agent: curl/7.64.1
 > Accept: */*
->
+> 
 < HTTP/1.1 200 OK
-< Date: Sat, 09 May 2020 01:30:06 GMT
+< Date: Wed, 26 Jan 2022 20:31:19 GMT
 < Transfer-Encoding: chunked
 < Connection: keep-alive
 < server: envoy
-< x-envoy-upstream-service-time: 0
-<
-* Connection #0 to host 80113f18-howtok8salb-color-0f20-319733316.us-west-2.elb.amazonaws.com left intact
-blue
+< x-envoy-upstream-service-time: 11
+< 
+* Connection #0 to host k8s-howtok8s-color-63786f35e6-1171992961.us-west-2.elb.amazonaws.com left intact
+green
 ```
 
 &nbsp;

--- a/walkthroughs/howto-k8s-alb/README.md
+++ b/walkthroughs/howto-k8s-alb/README.md
@@ -8,7 +8,7 @@ This example shows how to use [AWS Load Balancer Controller](https://github.com/
 - [Walkthrough: AWS Load Balancer Controller](https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.3/examples/echo_server/)
 - Install Docker. It is needed to build the demo application images.
 
-Note: Only [deploy the AWS Load Balancer controller](https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.3/examples/echo_server/#setup-the-aws-load-balancer-controller) and rest this example service will replace the echoserver in the AWS Load Balancer Controller link provider
+Note: Only [Setup the AWS Load Balancer controller](https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.3/examples/echo_server/#setup-the-aws-load-balancer-controller) and rest this example service will replace the echoserver mentioned in the AWS Load Balancer Controller page. That means you **don't** have to do the rest of the steps mentioned at [Deploy the echoserver resources](https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.3/examples/echo_server/#deploy-the-echoserver-resources).
 
 ## Setup
 

--- a/walkthroughs/howto-k8s-alb/README.md
+++ b/walkthroughs/howto-k8s-alb/README.md
@@ -8,7 +8,7 @@ This example shows how to use [AWS Load Balancer Controller](https://github.com/
 - [Walkthrough: AWS Load Balancer Controller](https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.3/examples/echo_server/)
 - Install Docker. It is needed to build the demo application images.
 
-Note: Only [setup the AWS Load Balancer controller](https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.3/examples/echo_server/#setup-the-aws-load-balancer-controller) and rest this example service will replace the echoserver in the AWS Load Balancer Controller link provider
+Note: Only [deploy the AWS Load Balancer controller](https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.3/examples/echo_server/#setup-the-aws-load-balancer-controller) and rest this example service will replace the echoserver in the AWS Load Balancer Controller link provider
 
 ## Setup
 


### PR DESCRIPTION
**Issue**
https://github.com/aws/aws-app-mesh-examples/issues/474

**Description of changes:**
Fix some broken links on howto-k8s-alb walkthrough README.md.

New readme for ref: [README.md](https://github.com/suniltheta/aws-app-mesh-examples/blob/fix_howto-k8s-alb/walkthroughs/howto-k8s-alb/README.md)

On aws-load-balancer-controller [repo](https://github.com/kubernetes-sigs/aws-load-balancer-controller)
> This project was formerly known as "AWS ALB Ingress Controller", we rebranded it to be "AWS Load Balancer Controller"

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
