### PR TITLE
include option3 to pull grpc_cli image from a public repo

### DIFF
--- a/walkthroughs/howto-grpc-ingress-gateway/README.md
+++ b/walkthroughs/howto-grpc-ingress-gateway/README.md
@@ -69,11 +69,15 @@ The front-end is Virtual Gateway that maintains a persistent gRPC connection to 
     export NLB_ENDPOINT=<your_public_endpoint e.g. howto-Publi-55555555.us-west-2.elb.amazonaws.com:80>
     ```
 2. You'll need to install the gRPC CLI tool:
-   **Option 1**: You can install the `grpc_cli` tool by following the link [here](https://github.com/grpc/grpc/blob/master/doc/command_line_tool.md)
+   **Option 1**: You can install the `grpc_cli` tool by following the link [here](https://github.com/grpc/grpc/blob/master/doc/command_line_tool.md)  
    **Option 2**: You can use the [Dockerfile](./Dockerfile) to build an ubuntu image with `grpc_cli` installed:
     ```
     docker build -t grpc_cli .
     docker run -it --rm grpc_cli
+    ```
+    **Option 3**: It takes significant time to build this image, so easier option is just to pull from this public repo
+    ```
+    git pull public.ecr.aws/suniltheta/grpc_cli:latest
     ```
 3. Try calling the `SetColor` method:
     ```

--- a/walkthroughs/howto-grpc-ingress-gateway/README.md
+++ b/walkthroughs/howto-grpc-ingress-gateway/README.md
@@ -78,6 +78,7 @@ The front-end is Virtual Gateway that maintains a persistent gRPC connection to 
     **Option 3**: It takes significant time to build this image, so easier option is just to pull from this public repo
     ```
     git pull public.ecr.aws/suniltheta/grpc_cli:latest
+    docker run -it --rm grpc_cli
     ```
 3. Try calling the `SetColor` method:
     ```


### PR DESCRIPTION
*Issue #, if available:*

**Description of changes:**

Add option 3 in the README.md to download the image from public ECR repo instead of building it new. Generating new takes 10+ minutes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
