### PR TITLE
Change --output from text to json as default when using jq

### DIFF
--- a/blogs/ecs-canary-deployments-pipeline/setup/scripts/create_sample_microservice_pipeline_stack.sh
+++ b/blogs/ecs-canary-deployments-pipeline/setup/scripts/create_sample_microservice_pipeline_stack.sh
@@ -32,11 +32,11 @@ done
 
 for item in "${sample_microservices[@]}"; do
     microservice="${item%%:*}"
-    while [ "$(aws cloudformation describe-stacks --stack-name ${ENVIRONMENT_NAME}-pipeline-${MICROSERVICE} --region $AWS_REGION | jq -r '.Stacks[0].StackStatus')" == "CREATE_IN_PROGRESS" ] ; do
+    while [ "$(aws cloudformation describe-stacks --stack-name ${ENVIRONMENT_NAME}-pipeline-${MICROSERVICE} --region $AWS_REGION --output json | jq -r '.Stacks[0].StackStatus')" == "CREATE_IN_PROGRESS" ] ; do
         echo -n '.'
         sleep 10
     done
-    if [ "$(aws cloudformation describe-stacks --stack-name ${ENVIRONMENT_NAME}-pipeline-${MICROSERVICE} --region $AWS_REGION | jq -r '.Stacks[0].StackStatus')" != "CREATE_COMPLETE" ] ; then
+    if [ "$(aws cloudformation describe-stacks --stack-name ${ENVIRONMENT_NAME}-pipeline-${MICROSERVICE} --region $AWS_REGION --output json | jq -r '.Stacks[0].StackStatus')" != "CREATE_COMPLETE" ] ; then
         echo -e "\nAn error occurred while creating the stack ${MICROSERVICE}! Don't move forward before fixing it!"
         exit 1
     fi

--- a/blogs/ecs-canary-deployments-pipeline/setup/scripts/create_shared_cloudformation_stack.sh
+++ b/blogs/ecs-canary-deployments-pipeline/setup/scripts/create_shared_cloudformation_stack.sh
@@ -51,8 +51,8 @@ aws cloudformation create-stack --stack-name $SHARED_STACK_NAME \
 
 # aws cloudformation wait stack-create-complete --stack-name $SHARED_STACK_NAME <Until the bug gets fixed, use the below workaround>
 echo -n "Creating the AWS CloudFormation stack"
-while [ "$(aws cloudformation describe-stacks --stack-name $SHARED_STACK_NAME --region $AWS_REGION | jq -r '.Stacks[0].StackStatus')" == "CREATE_IN_PROGRESS" ]; do
+while [ "$(aws cloudformation describe-stacks --stack-name $SHARED_STACK_NAME --region $AWS_REGION --output json | jq -r '.Stacks[0].StackStatus')" == "CREATE_IN_PROGRESS" ]; do
   echo -n '.'
   sleep 10
 done
-echo -e "\n$(aws cloudformation describe-stacks --stack-name $SHARED_STACK_NAME --region $AWS_REGION | jq -r '.Stacks[0].StackStatus')"
+echo -e "\n$(aws cloudformation describe-stacks --stack-name $SHARED_STACK_NAME --region $AWS_REGION --output json | jq -r '.Stacks[0].StackStatus')"

--- a/blogs/eks-appmesh-connectivity/deployments/infrastructure/setup-elasticache.sh
+++ b/blogs/eks-appmesh-connectivity/deployments/infrastructure/setup-elasticache.sh
@@ -14,7 +14,7 @@ aws ec2 wait security-group-exists \
     --filters Name=group-name,Values=yelb-es-security-group;Name=vpc-id,Values=${VPC_ID}
 
 SECURITY_GROUP_ID=$(echo $(aws ec2 describe-security-groups \
-    --filters Name=group-name,Values=yelb-es-security-group;Name=vpc-id,Values=${VPC_ID}) --output json \
+    --filters Name=group-name,Values=yelb-es-security-group;Name=vpc-id,Values=${VPC_ID} --output json)  \
     | jq -r '.SecurityGroups[0].GroupId')
 
 echo "Security Group Id: ${SECURITY_GROUP_ID}"

--- a/blogs/eks-appmesh-connectivity/deployments/infrastructure/setup-elasticache.sh
+++ b/blogs/eks-appmesh-connectivity/deployments/infrastructure/setup-elasticache.sh
@@ -2,7 +2,7 @@
 
 export AWS_DEFAULT_OUTPUT="json"
 
-VPC_ID=$(aws ec2 describe-vpcs --filters Name=isDefault,Values=true \
+VPC_ID=$(aws ec2 describe-vpcs --filters Name=isDefault,Values=true --output json \
     | jq -r '.Vpcs[0].VpcId')
 
 aws ec2 create-security-group \
@@ -14,7 +14,7 @@ aws ec2 wait security-group-exists \
     --filters Name=group-name,Values=yelb-es-security-group;Name=vpc-id,Values=${VPC_ID}
 
 SECURITY_GROUP_ID=$(echo $(aws ec2 describe-security-groups \
-    --filters Name=group-name,Values=yelb-es-security-group;Name=vpc-id,Values=${VPC_ID}) \
+    --filters Name=group-name,Values=yelb-es-security-group;Name=vpc-id,Values=${VPC_ID}) --output json \
     | jq -r '.SecurityGroups[0].GroupId')
 
 echo "Security Group Id: ${SECURITY_GROUP_ID}"
@@ -39,6 +39,6 @@ aws elasticache wait cache-cluster-available \
 
 CLUSTER_END_POINT=$(aws elasticache describe-cache-clusters \
     --cache-cluster-id yelb-cache-cluster \
-    --show-cache-node-info | jq -r '.CacheClusters[0].CacheNodes[0].Endpoint.Address')
+    --show-cache-node-info --output json | jq -r '.CacheClusters[0].CacheNodes[0].Endpoint.Address')
 
 echo "ElastiCache endpoint: ${CLUSTER_END_POINT}"

--- a/blogs/eks-appmesh-connectivity/deployments/infrastructure/setup-rds.sh
+++ b/blogs/eks-appmesh-connectivity/deployments/infrastructure/setup-rds.sh
@@ -2,7 +2,7 @@
 
 export AWS_DEFAULT_OUTPUT="json"
 
-VPC_ID=$(aws ec2 describe-vpcs --filters Name=isDefault,Values=true | jq -r '.Vpcs[0].VpcId')
+VPC_ID=$(aws ec2 describe-vpcs --filters Name=isDefault,Values=true --output json | jq -r '.Vpcs[0].VpcId')
 
 aws ec2 create-security-group \
     --group-name yelb-db-security-group \
@@ -13,7 +13,7 @@ aws ec2 wait security-group-exists \
     --filters Name=group-name,Values=yelb-es-security-group;Name=vpc-id,Values=${VPC_ID}
 
 SECURITY_GROUP_ID=$(echo $(aws ec2 describe-security-groups \
-    --filters Name=group-name,Values=yelb-db-security-group;Name=vpc-id,Values=${VPC_ID}) | jq -r '.SecurityGroups[0].GroupId')
+    --filters Name=group-name,Values=yelb-db-security-group;Name=vpc-id,Values=${VPC_ID}) --output json | jq -r '.SecurityGroups[0].GroupId')
 
 echo "Security Group Id: ${SECURITY_GROUP_ID}"
 
@@ -42,6 +42,6 @@ aws rds wait db-instance-available \
     --db-instance-identifier yelb-db-instance
 
 CLUSTER_END_POINT=$(aws rds describe-db-clusters \
-    --db-cluster-identifier yelb-db-cluster | jq -r '.DBClusters[0].Endpoint')
+    --db-cluster-identifier yelb-db-cluster --output json | jq -r '.DBClusters[0].Endpoint')
 
 echo "RDS endpoint: ${CLUSTER_END_POINT}"

--- a/blogs/eks-canary-deployments-pipeline/setup/add_iam_role_to_rbac.sh
+++ b/blogs/eks-canary-deployments-pipeline/setup/add_iam_role_to_rbac.sh
@@ -4,9 +4,9 @@
 source ~/.bash_profile
 
 # Get the AWS Lambda role ARN
-STATE_MACHINE_ROLE_ARN=$(aws cloudformation describe-stacks --region $AWS_REGION --stack-name $SHARED_STACK_NAME \
+STATE_MACHINE_ROLE_ARN=$(aws cloudformation describe-stacks --region $AWS_REGION --stack-name $SHARED_STACK_NAME --output json \
 | jq -r '.Stacks[0].Outputs[] | select(.OutputKey == "EKSAccessRole") | .OutputValue')
 
 # Add the role to Kubernetes RBAC
-eksctl create iamidentitymapping --region $AWS_REGION --cluster $EKS_CLUSTER_NAME --arn $STATE_MACHINE_ROLE_ARN \
+eksctl create iamidentitymapping --region $AWS_REGION --cluster $EKS_CLUSTER_NAME --arn $STATE_MACHINE_ROLE_ARN --output json \
 --group system:masters --username eks_canary_stepfunctions

--- a/blogs/eks-canary-deployments-pipeline/setup/aws_lambda_layer.sh
+++ b/blogs/eks-canary-deployments-pipeline/setup/aws_lambda_layer.sh
@@ -5,7 +5,7 @@ APP_ID='arn:aws:serverlessrepo:us-east-1:903779448426:applications/lambda-layer-
 
 # Create the AWS CloudFormation template
 TEMPLATE_URL=$(aws --region $AWS_REGION serverlessrepo \
-create-cloud-formation-template --application-id  ${APP_ID} \
+create-cloud-formation-template --application-id  ${APP_ID} --output json \
 | jq -r '.TemplateUrl')
 
 # Deploy the AWS CloudFormation template
@@ -15,8 +15,8 @@ aws --region $AWS_REGION cloudformation create-stack \
 --parameters ParameterKey=LayerName,ParameterValue=lambda-layer-kubectl
 
 echo -n "Creating the AWS CloudFormation stack"
-while [ "$(aws cloudformation describe-stacks --stack-name kubectl-lambda-layer --region $AWS_REGION | jq -r '.Stacks[0].StackStatus')" == "CREATE_IN_PROGRESS" ]; do
+while [ "$(aws cloudformation describe-stacks --stack-name kubectl-lambda-layer --region $AWS_REGION --output json | jq -r '.Stacks[0].StackStatus')" == "CREATE_IN_PROGRESS" ]; do
   echo -n '.'
   sleep 10
 done
-echo -e "\n$(aws cloudformation describe-stacks --stack-name kubectl-lambda-layer --region $AWS_REGION | jq -r '.Stacks[0].StackStatus')"
+echo -e "\n$(aws cloudformation describe-stacks --stack-name kubectl-lambda-layer --region $AWS_REGION --output json | jq -r '.Stacks[0].StackStatus')"

--- a/blogs/eks-canary-deployments-pipeline/setup/create_eks_cluster.sh
+++ b/blogs/eks-canary-deployments-pipeline/setup/create_eks_cluster.sh
@@ -6,10 +6,10 @@ eksctl create cluster --name $EKS_CLUSTER_NAME --region $AWS_REGION --zones="$AW
 --alb-ingress-access --full-ecr-access
 
 # Export cluster ARN (this variable will be used later)
-export EKS_CLUSTER_ARN=$(aws eks describe-cluster --region $AWS_REGION --name $EKS_CLUSTER_NAME | jq -r '.cluster.arn')
+export EKS_CLUSTER_ARN=$(aws eks describe-cluster --region $AWS_REGION --name $EKS_CLUSTER_NAME --output json | jq -r '.cluster.arn')
 echo "export EKS_CLUSTER_ARN=${EKS_CLUSTER_ARN}" | tee -a ~/.bash_profile
 
 # Export node group role name (this variable will be used later)
 export STACK_NAME=$(eksctl get nodegroup --region $AWS_REGION --cluster $EKS_CLUSTER_NAME -o json | jq -r '.[].StackName')
-export EKS_ROLE_NAME=$(aws cloudformation describe-stack-resources --region $AWS_REGION --stack-name $STACK_NAME | jq -r '.StackResources[] | select(.ResourceType=="AWS::IAM::Role") | .PhysicalResourceId')
+export EKS_ROLE_NAME=$(aws cloudformation describe-stack-resources --region $AWS_REGION --stack-name $STACK_NAME --output json | jq -r '.StackResources[] | select(.ResourceType=="AWS::IAM::Role") | .PhysicalResourceId')
 echo "export EKS_ROLE_NAME=${EKS_ROLE_NAME}" | tee -a ~/.bash_profile

--- a/blogs/eks-canary-deployments-pipeline/setup/create_microservice_pipeline_stack.sh
+++ b/blogs/eks-canary-deployments-pipeline/setup/create_microservice_pipeline_stack.sh
@@ -49,18 +49,18 @@ ParameterKey=SampleMicroservices,ParameterValue="$USE_SAMPLE_MICROSERVICES" \
 
 
 echo -n "Creating the AWS CloudFormation stacks"
-while [ "$(aws cloudformation describe-stacks --stack-name eks-pipeline-yelb-db --region $AWS_REGION | jq -r '.Stacks[0].StackStatus')" == "CREATE_IN_PROGRESS" ] || \
-[ "$(aws cloudformation describe-stacks --stack-name eks-pipeline-yelb-redis --region $AWS_REGION | jq -r '.Stacks[0].StackStatus')" == "CREATE_IN_PROGRESS" ] || \
-[ "$(aws cloudformation describe-stacks --stack-name eks-pipeline-yelb-appserver --region $AWS_REGION | jq -r '.Stacks[0].StackStatus')" == "CREATE_IN_PROGRESS" ] || \
-[ "$(aws cloudformation describe-stacks --stack-name eks-pipeline-yelb-ui --region $AWS_REGION | jq -r '.Stacks[0].StackStatus')" == "CREATE_IN_PROGRESS" ] ; do
+while [ "$(aws cloudformation describe-stacks --stack-name eks-pipeline-yelb-db --region $AWS_REGION --output json | jq -r '.Stacks[0].StackStatus')" == "CREATE_IN_PROGRESS" ] || \
+[ "$(aws cloudformation describe-stacks --stack-name eks-pipeline-yelb-redis --region $AWS_REGION --output json | jq -r '.Stacks[0].StackStatus')" == "CREATE_IN_PROGRESS" ] || \
+[ "$(aws cloudformation describe-stacks --stack-name eks-pipeline-yelb-appserver --region $AWS_REGION --output json | jq -r '.Stacks[0].StackStatus')" == "CREATE_IN_PROGRESS" ] || \
+[ "$(aws cloudformation describe-stacks --stack-name eks-pipeline-yelb-ui --region $AWS_REGION --output json | jq -r '.Stacks[0].StackStatus')" == "CREATE_IN_PROGRESS" ] ; do
   echo -n '.'
   sleep 10
 done
 
-if [ "$(aws cloudformation describe-stacks --stack-name eks-pipeline-yelb-db --region $AWS_REGION | jq -r '.Stacks[0].StackStatus')" == "CREATE_COMPLETE" ] && \
-[ "$(aws cloudformation describe-stacks --stack-name eks-pipeline-yelb-redis --region $AWS_REGION | jq -r '.Stacks[0].StackStatus')" == "CREATE_COMPLETE" ] && \
-[ "$(aws cloudformation describe-stacks --stack-name eks-pipeline-yelb-appserver --region $AWS_REGION | jq -r '.Stacks[0].StackStatus')" == "CREATE_COMPLETE" ] && \
-[ "$(aws cloudformation describe-stacks --stack-name eks-pipeline-yelb-ui --region $AWS_REGION | jq -r '.Stacks[0].StackStatus')" == "CREATE_COMPLETE" ] ; then
+if [ "$(aws cloudformation describe-stacks --stack-name eks-pipeline-yelb-db --region $AWS_REGION --output json | jq -r '.Stacks[0].StackStatus')" == "CREATE_COMPLETE" ] && \
+[ "$(aws cloudformation describe-stacks --stack-name eks-pipeline-yelb-redis --region $AWS_REGION --output json | jq -r '.Stacks[0].StackStatus')" == "CREATE_COMPLETE" ] && \
+[ "$(aws cloudformation describe-stacks --stack-name eks-pipeline-yelb-appserver --region $AWS_REGION --output json | jq -r '.Stacks[0].StackStatus')" == "CREATE_COMPLETE" ] && \
+[ "$(aws cloudformation describe-stacks --stack-name eks-pipeline-yelb-ui --region $AWS_REGION --output json | jq -r '.Stacks[0].StackStatus')" == "CREATE_COMPLETE" ] ; then
     echo -e "\nAll four stacks created successfully!"
 else
     echo -e "\nAn error occurred while creating the stacks! Don't move forward before fixing it!"

--- a/blogs/eks-canary-deployments-pipeline/setup/create_shared_cloudformation_stack.sh
+++ b/blogs/eks-canary-deployments-pipeline/setup/create_shared_cloudformation_stack.sh
@@ -69,7 +69,7 @@ aws s3 cp ./ s3://$S3_BUCKET_NAME --recursive --region $AWS_REGION > /dev/null
 
 # Get the AWS Lambda Layer ARN from last AWS CloudFormation stack output
 LAMBDA_LAYER_ARN=$(aws cloudformation describe-stacks --stack-name kubectl-lambda-layer \
---region $AWS_REGION | jq -r '.Stacks[0].Outputs[] | select(.OutputKey == "LayerVersionArn") | .OutputValue')
+--region $AWS_REGION --output json | jq -r '.Stacks[0].Outputs[] | select(.OutputKey == "LayerVersionArn") | .OutputValue')
 
 # Deploy AWS CloudFormation Stack
 aws cloudformation create-stack --stack-name $SHARED_STACK_NAME \
@@ -81,11 +81,11 @@ ParameterKey=LambdaLayerName,ParameterValue="$LAMBDA_LAYER_ARN" \
 --region $AWS_REGION
 
 echo -n "Creating the AWS CloudFormation stack"
-while [ "$(aws cloudformation describe-stacks --stack-name $SHARED_STACK_NAME --region $AWS_REGION | jq -r '.Stacks[0].StackStatus')" == "CREATE_IN_PROGRESS" ]; do
+while [ "$(aws cloudformation describe-stacks --stack-name $SHARED_STACK_NAME --region $AWS_REGION --output json | jq -r '.Stacks[0].StackStatus')" == "CREATE_IN_PROGRESS" ]; do
   echo -n '.'
   sleep 10
 done
-echo -e "\n$(aws cloudformation describe-stacks --stack-name $SHARED_STACK_NAME --region $AWS_REGION | jq -r '.Stacks[0].StackStatus')"
+echo -e "\n$(aws cloudformation describe-stacks --stack-name $SHARED_STACK_NAME --region $AWS_REGION --output json | jq -r '.Stacks[0].StackStatus')"
 
 
 #Cleanup

--- a/blogs/eks-multi-account-spire/helper-scripts/app_mesh_setup.sh
+++ b/blogs/eks-multi-account-spire/helper-scripts/app_mesh_setup.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-MESH_OWNER=$(aws --profile shared sts get-caller-identity | jq -r .Account)
+MESH_OWNER=$(aws --profile shared sts get-caller-identity --output json | jq -r .Account)
 
 cat << EOF > app-mesh.yaml
 apiVersion: appmesh.k8s.aws/v1beta2
@@ -65,7 +65,7 @@ for PROFILE in shared frontend backend
     kubectl label namespace yelb "appmesh.k8s.aws/sidecarInjectorWebhook"=enabled
 
     if [ "$PROFILE" != "shared" ]; then 
-      INVITE_ARN=$(aws --profile $PROFILE ram get-resource-share-invitations \
+      INVITE_ARN=$(aws --profile $PROFILE ram get-resource-share-invitations --output json \
         | jq -r '.resourceShareInvitations[] | select(.resourceShareName=="mesh-share") | .resourceShareInvitationArn')
       if [ "$INVITE_ARN" != "" ]; then
         echo "Accepting resource share..."
@@ -92,8 +92,8 @@ for PROFILE in shared frontend backend
         --name mesh-share \
         --resource-arns $(kubectl get meshes -o json \
         | jq -r '.items[] | select(.metadata.name =="am-multi-account-mesh").status.meshARN') \
-        --principals $(aws --profile frontend sts get-caller-identity | jq -r .Account) \
-        $(aws --profile backend sts get-caller-identity | jq -r .Account) > /dev/null
+        --principals $(aws --profile frontend sts get-caller-identity --output json | jq -r .Account) \
+        $(aws --profile backend sts get-caller-identity --output json | jq -r .Account) > /dev/null
     fi
 
     if [ "$PROFILE" == "backend" ]; then

--- a/blogs/eks-multi-account-spire/helper-scripts/cleanup.sh
+++ b/blogs/eks-multi-account-spire/helper-scripts/cleanup.sh
@@ -20,9 +20,9 @@ for PROFILE in frontend backend shared
 
     if [ "$PROFILE" == "backend" ]; then 
       echo "Deleting the Cloud Map namespace am-multi-account.local..."
-      aws --profile backend servicediscovery get-operation \
+      aws --output json --profile backend servicediscovery get-operation \
         --operation-id $(aws --profile backend servicediscovery delete-namespace \
-        --id $(aws --profile backend servicediscovery list-namespaces \
+        --id $(aws --profile backend servicediscovery list-namespaces --output json \
         | jq -r '.Namespaces[] | select(.Name=="am-multi-account.local").Id') \
         | jq -r '.OperationId') > /dev/null
     fi
@@ -34,7 +34,7 @@ for PROFILE in frontend backend shared
       echo "Deleting the mesh-share RAM resource share..."
       aws --profile shared ram delete-resource-share \
         --resource-share-arn $(aws --profile shared ram get-resource-shares \
-        --resource-owner SELF | jq -r '.resourceShares[] | select((.name=="mesh-share") and (.status=="ACTIVE")).resourceShareArn') > /dev/null
+        --resource-owner SELF --output json | jq -r '.resourceShares[] | select((.name=="mesh-share") and (.status=="ACTIVE")).resourceShareArn') > /dev/null
     fi 
 
     echo "Deleting the appmesh-controller..."

--- a/blogs/eks-multi-account-spire/helper-scripts/kubeconfig.sh
+++ b/blogs/eks-multi-account-spire/helper-scripts/kubeconfig.sh
@@ -12,7 +12,7 @@ aws --profile frontend eks update-kubeconfig \
   --kubeconfig front_config \
   --name eks-cluster-frontend \
   --role-arn $(aws --profile frontend iam get-role \
-  --role-name eks-cluster-frontend-access-role | jq -r '.Role.Arn')
+  --role-name eks-cluster-frontend-access-role --output json | jq -r '.Role.Arn')
 
 # remove AWS_PROFILE from the frontend kubeconfig file
 sed "$(( $(wc -l <front_config)-3+1 )),$ d" front_config \
@@ -38,7 +38,7 @@ aws --profile backend eks update-kubeconfig \
   --kubeconfig back_config \
   --name eks-cluster-backend \
   --role-arn $(aws --profile backend iam get-role \
-  --role-name eks-cluster-backend-access-role | jq -r '.Role.Arn')
+  --role-name eks-cluster-backend-access-role --output json | jq -r '.Role.Arn')
  
 # remove AWS_PROFILE from the backend kubeconfig file
 sed "$(( $(wc -l <back_config)-3+1 )),$ d" back_config \

--- a/examples/apps/colorapp/ecs/create-task-defs.sh
+++ b/examples/apps/colorapp/ecs/create-task-defs.sh
@@ -20,7 +20,7 @@ if [ -z "${COLOR_TELLER_IMAGE}" ]; then
 fi
 
 stack_output=$(aws --profile "${AWS_PROFILE}" --region "${AWS_DEFAULT_REGION}" \
-    cloudformation describe-stacks --stack-name "${ENVIRONMENT_NAME}-ecs-cluster" \
+    cloudformation describe-stacks --stack-name "${ENVIRONMENT_NAME}-ecs-cluster" --output json \
     | jq '.Stacks[].Outputs[]')
 
 task_role_arn=($(echo $stack_output \
@@ -79,7 +79,8 @@ generate_color_teller_task_def() {
     -f "${DIR}/colorteller-base-task-def.json")
     task_def=$(aws --profile "${AWS_PROFILE}" --region "${AWS_DEFAULT_REGION}" \
     ecs register-task-definition \
-    --cli-input-json "$task_def_json")
+    --cli-input-json "$task_def_json" \
+    --output json)
 }
 
 # Color Gateway Task Definition
@@ -100,7 +101,8 @@ task_def_json=$(jq -n \
     -f "${DIR}/colorgateway-base-task-def.json")
 task_def=$(aws --profile "${AWS_PROFILE}" --region "${AWS_DEFAULT_REGION}" \
     ecs register-task-definition \
-    --cli-input-json "$task_def_json")
+    --cli-input-json "$task_def_json" \
+    --output json )
 colorgateway_task_def_arn=($(echo $task_def \
     | jq -r '.taskDefinition | .taskDefinitionArn'))
 


### PR DESCRIPTION
*Issue #, if available:*
Currently, some of AWS CLI APIs are having `--output text` as default value; however, when using with `jq`, it would not possible for us to extract the object properties when finished calling the API.

*Description of changes:*
Add flag `--output json` for AWS CLI APIS when there is a `jq` request.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
