### PR TITLE
Limit spire configmap access to namespace

### DIFF
--- a/walkthroughs/howto-k8s-mtls-sds-based/spire/spire_setup.yaml
+++ b/walkthroughs/howto-k8s-mtls-sds-based/spire/spire_setup.yaml
@@ -15,6 +15,30 @@ metadata:
   name: spire-agent
   namespace: spire
 ---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: spire-server-configmap-role
+  namespace: spire
+rules:
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["patch", "get", "list"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: spire-server-configmap-role-binding
+  namespace: spire
+subjects:
+- kind: ServiceAccount
+  name: spire-server
+  namespace: spire
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: spire-server-configmap-role
+---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -23,10 +47,6 @@ rules:
 - apiGroups: ["authentication.k8s.io"]
   resources: ["tokenreviews"]
   verbs: ["create"]
-- apiGroups: [""]
-  resources: ["configmaps"]
-  verbs: ["patch", "get", "list"]
-
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Moving the configmap permission for spire-server account from ClusterRole to Role. Role scopes the configmap access down to a single namespace. Spire only needs to read config maps in its own namespace.

[Similar PR for eks charts](https://github.com/aws/eks-charts/pull/717)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
