### PR TITLE
Fix README instructions nits

### DIFF
--- a/walkthroughs/eks/base.md
+++ b/walkthroughs/eks/base.md
@@ -62,7 +62,7 @@ Run the following set of commands to install the App Mesh controller
 helm repo add eks https://aws.github.io/eks-charts
 helm repo update
 kubectl create ns appmesh-system
-kubectl apply -k https://github.com/aws/eks-charts/stable/appmesh-controller/crds?ref=master
+kubectl apply -k "https://github.com/aws/eks-charts/stable/appmesh-controller/crds?ref=master"
 helm upgrade -i appmesh-controller eks/appmesh-controller --namespace appmesh-system
 
 ```

--- a/walkthroughs/howto-k8s-http2/README.md
+++ b/walkthroughs/howto-k8s-http2/README.md
@@ -29,6 +29,10 @@ You can use v1beta1 example manifest with [aws-app-mesh-controller-for-k8s](http
     ```
     helm upgrade -i appmesh-controller eks/appmesh-controller --namespace appmesh-system --set sidecar.image.repository=840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-envoy --set sidecar.image.tag=<VERSION>
     ```
+1. **VPC_ID** environment variable is set to the VPC where Kubernetes pods are launched. VPC will be used to setup private DNS namespace in AWS using create-private-dns-namespace API. To find out VPC of EKS cluster you can use aws eks describe-cluster.
+    ```
+    export VPC_ID=...
+    ```
 1. Deploy
     ```.
     ./deploy.sh


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Update base.md with proper syntax for `kubectl apply` command

```
$ kubectl apply -k https://github.com/aws/eks-charts/stable/appmesh-controller/crds?ref=master  

zsh: no matches found: https://github.com/aws/eks-charts/stable/appmesh-controller/crds?ref=master
```

* Update howto-k8s-http2 README with VPC_ID instructions

```
VPC_ID must be set. VPC_ID corresponds to vpc where applications are deployed.
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
