### PR TITLE
remove preview from timeout_policy walkthrough

### DIFF
--- a/walkthroughs/howto-timeout-policy/mesh/mesh.sh
+++ b/walkthroughs/howto-timeout-policy/mesh/mesh.sh
@@ -23,7 +23,7 @@ sanity_check() {
     fi
 }
 
-appmesh_cmd="aws appmesh-preview"
+appmesh_cmd="aws appmesh"
 
 create_mesh() {
     spec_file=$1


### PR DESCRIPTION
**Description of changes:**

Timeout policy walkthrough doesn't need appmesh preview. I forgot to update the shell script in my previous PR https://github.com/aws/aws-app-mesh-examples/pull/491


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
