### PR TITLE
updating the cert-manager configuration files for the blog post

### DIFF
--- a/blogs/cert-manager-tls/README.md
+++ b/blogs/cert-manager-tls/README.md
@@ -1,6 +1,6 @@
 # Securing Kubernetes applications with AWS App Mesh and cert-manager
 
-Full configuration files for blog post [Securing Kubernetes applications with AWS App Mesh and cert-manager]()
+Full configuration files for blog post [Securing Kubernetes applications with AWS App Mesh and cert-manager](https://aws.amazon.com/blogs/containers/securing-kubernetes-applications-with-aws-app-mesh-and-cert-manager/)
 
 ## 0. Deploy base yelb with App Mesh
 
@@ -17,7 +17,7 @@ helm repo update
 helm install \
   cert-manager jetstack/cert-manager \
   --namespace cert-manager \
-  --version v0.16.1 \
+  --version v1.8.1 \
   --set installCRDs=true
 ```
 

--- a/blogs/cert-manager-tls/ca-issuer.yaml
+++ b/blogs/cert-manager-tls/ca-issuer.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: ca-issuer

--- a/blogs/cert-manager-tls/yelb-cert.yaml
+++ b/blogs/cert-manager-tls/yelb-cert.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: yelb-cert-ui
@@ -11,7 +11,7 @@ spec:
   issuerRef:
     name: ca-issuer  
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: yelb-cert-app
@@ -23,7 +23,7 @@ spec:
   issuerRef:
     name: ca-issuer
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: yelb-cert-db
@@ -35,7 +35,7 @@ spec:
   issuerRef:
     name: ca-issuer
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: yelb-cert-redis
@@ -47,7 +47,7 @@ spec:
   issuerRef:
     name: ca-issuer
 ---      
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: yelb-cert-gw

--- a/blogs/cert-manager-tls/yelb-gw.yaml
+++ b/blogs/cert-manager-tls/yelb-gw.yaml
@@ -52,7 +52,7 @@ spec:
           virtualServiceRef:
             name: yelb-ui
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: yelb-cert-gw


### PR DESCRIPTION
Updating the configuration files of the blog post "Securing Kubernetes applications with AWS App Mesh and cert-manager" with the latest version of cert-manager (v0.16.1 -->v1.8.1) and supported version of the cert-manager API (v1alpha2 --> v1) 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.