### PR TITLE
added noopener and noreferrer to href

### DIFF
--- a/blogs/ecs-service-connectivity/yelb/yelb-ui/clarity-seed-newfiles/src/app/app.component.html
+++ b/blogs/ecs-service-connectivity/yelb/yelb-ui/clarity-seed-newfiles/src/app/app.component.html
@@ -32,13 +32,13 @@
                                 </div>
                                 <ul class="list-group list-group-flush">
                                     <li class="list-group-item">
-                                        <a href="http://www.ihop.com/" target="_blank"><b>Pancakes</b>, for a powerful start!</a>
+                                        <a href="http://www.ihop.com/" target="_blank" rel="noopener noreferrer"><b>Pancakes</b>, for a powerful start!</a>
                                     </li>
                                 </ul>
                                  <ul class="list-group list-group-recipepuppy">
                                     <li class="list-group-item">
                                         <clr-icon shape="note" size="20" style="color: #00A98C;"></clr-icon>
-                                        <a href={{recipelink_pancakes}} target="_blank"><b>Pancakes - Recipe</b></a>
+                                        <a href={{recipelink_pancakes}} target="_blank" rel="noopener noreferrer"><b>Pancakes - Recipe</b></a>
                                     </li>
                                 </ul>
                                 <div class="card-footer">
@@ -54,13 +54,13 @@
                                 </div>
                                 <ul class="list-group list-group-flush">
                                     <li class="list-group-item">
-                                        <a href="https://www.chipotle.com/" target="_blank"><b>Burritos</b>, for a mid-day break!</a>
+                                        <a href="https://www.chipotle.com/" target="_blank" rel="noopener noreferrer"><b>Burritos</b>, for a mid-day break!</a>
                                     </li>
                                 </ul>
                                  <ul class="list-group list-group-recipepuppy">
                                    <li class="list-group-item">
                                         <clr-icon shape="note" size="20" style="color: #00A98C;"></clr-icon>
-                                        <a href={{recipelink_burritos}} target="_blank"><b>Burritos - Recipe</b></a>
+                                        <a href={{recipelink_burritos}} target="_blank" rel="noopener noreferrer"><b>Burritos - Recipe</b></a>
                                     </li>
                                 </ul>
                                 <div class="card-footer">
@@ -77,13 +77,13 @@
                                 </div>
                                 <ul class="list-group list-group-flush">
                                     <li class="list-group-item">
-                                        <a href="https://www.outback.com/" target="_blank"><b>Blooming onion</b>, what else?</a>
+                                        <a href="https://www.outback.com/" target="_blank" rel="noopener noreferrer"><b>Blooming onion</b>, what else?</a>
                                     </li>
                                 </ul>
                                  <ul class="list-group list-group-recipepuppy">
                                   <li class="list-group-item">
                                         <clr-icon shape="note" size="20" style="color: #00A98C;"></clr-icon>
-                                        <a href={{recipelink_steak}} target="_blank"><b>Steak - Recipe</b></a>
+                                        <a href={{recipelink_steak}} target="_blank" rel="noopener noreferrer"><b>Steak - Recipe</b></a>
                                     </li>
                                 </ul>
                                 <div class="card-footer">
@@ -99,13 +99,13 @@
                                 </div>
                                 <ul class="list-group list-group-flush">
                                     <li class="list-group-item">
-                                        <a href="http://www.bucadibeppo.com/" target="_blank"><b>Lasagne</b>, this is heaven!</a>
+                                        <a href="http://www.bucadibeppo.com/" target="_blank" rel="noopener noreferrer"><b>Lasagne</b>, this is heaven!</a>
                                     </li>
                                 </ul>
                                   <ul class="list-group list-group-recipepuppy">
                                   <li class="list-group-item">
                                         <clr-icon shape="note" size="20" style="color: #00A98C;"></clr-icon>
-                                        <a href={{recipelink_lasagne}} target="_blank"><b>Lasagne - Recipe</b></a>
+                                        <a href={{recipelink_lasagne}} target="_blank" rel="noopener noreferrer"><b>Lasagne - Recipe</b></a>
                                     </li>
                                 </ul>
                                 <div class="card-footer">
@@ -182,7 +182,7 @@
 
 
                         <div class="col-sm-12 col-md-6 col-xl-3">
-                                <a href="http://clarity.design" class="card clickable" target="_blank">
+                                <a href="http://clarity.design" class="card clickable" target="_blank" rel="noopener noreferrer">
                                     <div class="card-block">
                                         <p class="card-text">
                                             <img src="https://vmware.github.io/clarity/clarity_logo.21dda15557a6ebf26fce.svg" style="width: 24px; margin-right: 12px;">Clarity Design System


### PR DESCRIPTION
**Issue:** Reverse tabnabbing

**Observed:** 
when a link is configured to open a new tab in a browser by, for example, adding the target="_blank" attribute to an <a> tag. If done incorrectly, the new page is able to control the referrer and opener objects of the parent window, and use that control to replace the parent site with a phishing site.

**Description of changes:** Added the noopener and noreferrer values in the rel attribute in <a> tags


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
