### PR TITLE
Updating the Dockerfile used to build envoy image

### DIFF
--- a/walkthroughs/howto-mutual-tls-file-provided-by-acm/src/customEnvoyImage/Dockerfile
+++ b/walkthroughs/howto-mutual-tls-file-provided-by-acm/src/customEnvoyImage/Dockerfile
@@ -1,5 +1,6 @@
 ARG ENVOY_IMAGE
-FROM ${ENVOY_IMAGE}
+FROM ${ENVOY_IMAGE} as envoy
+FROM public.ecr.aws/amazonlinux/amazonlinux:2
 
 ARG AWS_DEFAULT_REGION
 
@@ -12,6 +13,10 @@ RUN yum update -y && \
     rm -rf awscliv2.zip ./aws/install && \
     yum clean all && \
     rm -rf /var/cache/yum
+
+COPY --from=envoy /usr/bin/envoy /usr/bin/envoy
+COPY --from=envoy /usr/bin/agent /usr/bin/agent
+COPY --from=envoy /aws_appmesh_aggregate_stats.wasm /aws_appmesh_aggregate_stats.wasm
 
 RUN mkdir /keys && chown 1337:1337 /keys 
 

--- a/walkthroughs/howto-mutual-tls-file-provided/src/customEnvoyImage/Dockerfile
+++ b/walkthroughs/howto-mutual-tls-file-provided/src/customEnvoyImage/Dockerfile
@@ -1,8 +1,7 @@
 ARG ENVOY_IMAGE
-FROM ${ENVOY_IMAGE}
-
+FROM ${ENVOY_IMAGE} as envoy
+FROM public.ecr.aws/amazonlinux/amazonlinux:2
 ARG AWS_DEFAULT_REGION
-
 RUN yum update -y && \
     yum install -y jq curl unzip less && \
     curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
@@ -12,6 +11,10 @@ RUN yum update -y && \
     rm -rf awscliv2.zip ./aws/install && \
     yum clean all && \
     rm -rf /var/cache/yum
+
+COPY --from=envoy /usr/bin/envoy /usr/bin/envoy
+COPY --from=envoy /usr/bin/agent /usr/bin/agent
+COPY --from=envoy /aws_appmesh_aggregate_stats.wasm /aws_appmesh_aggregate_stats.wasm
 
 RUN mkdir /keys && chown 1337:1337 /keys 
 


### PR DESCRIPTION
Adding new lines to the Dockerfile to overcome the "/bin/sh: yum: command not found." issue. 

*Issue #, if available:*

https://github.com/aws/aws-app-mesh-examples/issues/512

*Description of changes:*
I made changes to the Dockerfile below to overcome this issue.  
[https://github.com/aws/aws-app-mesh-examples/blob/main/walkthroughs/howto-mutual-tls-file-provided/src/customEnvoyImage/Dockerfile]

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
