### PR TITLE
Updating the Dockerfile to include the al2 image

### DIFF
--- a/walkthroughs/howto-mutual-tls-file-provided-by-acm/src/customEnvoyImage/Dockerfile
+++ b/walkthroughs/howto-mutual-tls-file-provided-by-acm/src/customEnvoyImage/Dockerfile
@@ -1,10 +1,9 @@
 ARG ENVOY_IMAGE
-FROM ${ENVOY_IMAGE}
-
+FROM ${ENVOY_IMAGE} as envoy
+FROM public.ecr.aws/amazonlinux/amazonlinux:2
 ARG AWS_DEFAULT_REGION
-
 RUN yum update -y && \
-    yum install -y jq curl unzip openssl less && \
+    yum install -y jq curl unzip less && \
     curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
     unzip awscliv2.zip && \
     ./aws/install && \
@@ -12,6 +11,10 @@ RUN yum update -y && \
     rm -rf awscliv2.zip ./aws/install && \
     yum clean all && \
     rm -rf /var/cache/yum
+
+COPY --from=envoy /usr/bin/envoy /usr/bin/envoy
+COPY --from=envoy /usr/bin/agent /usr/bin/agent
+COPY --from=envoy /aws_appmesh_aggregate_stats.wasm /aws_appmesh_aggregate_stats.wasm
 
 RUN mkdir /keys && chown 1337:1337 /keys 
 

--- a/walkthroughs/howto-mutual-tls-file-provided-by-acm/src/customEnvoyImage/Dockerfile
+++ b/walkthroughs/howto-mutual-tls-file-provided-by-acm/src/customEnvoyImage/Dockerfile
@@ -3,7 +3,7 @@ FROM ${ENVOY_IMAGE} as envoy
 FROM public.ecr.aws/amazonlinux/amazonlinux:2
 ARG AWS_DEFAULT_REGION
 RUN yum update -y && \
-    yum install -y jq curl unzip less && \
+    yum install -y jq curl openssl unzip less && \
     curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
     unzip awscliv2.zip && \
     ./aws/install && \


### PR DESCRIPTION
Updating the Dockerfile to include the al2 image, otherwise building the docker image using this Dockerfile is going to give yum not found messages as discussed here https://github.com/aws/aws-app-mesh-examples/issues/512.

*Issue #, if available:*

https://github.com/aws/aws-app-mesh-examples/issues/512

*Description of changes:*

Adding al2 base image to get the yum command working. The new resulting Dockerfile is going to be a multistage build. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
