### PR TITLE
Update Color App EC2 Image to AL2

### DIFF
--- a/examples/infrastructure/ecs-cluster.yaml
+++ b/examples/infrastructure/ecs-cluster.yaml
@@ -33,7 +33,7 @@ Parameters:
   ECSAmi:
     Description: ECS AMI ID
     Type: AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
-    Default: "/aws/service/ecs/optimized-ami/amazon-linux/recommended/image_id"
+    Default: "/aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id"
 
   EC2Ami:
     Description: EC2 AMI ID
@@ -188,7 +188,7 @@ Resources:
                 files:
                   - /etc/cfn/cfn-hup.conf
                   - /etc/cfn/hooks.d/cfn-auto-reloader.conf
-              awslogs:
+              awslogsd:
                 enabled: true
                 ensureRunning: true
                 files:


### PR DESCRIPTION


*Issue #, if available:*

*Description of changes:*

This updates the autoscaling ec2 group to use AL2. The name of the awslog daemon changed from awlogs to awslogsd in this update, and the init config was updated appropriately.

For testing, I performed a full runthrough of [this guide](https://github.com/aws/aws-app-mesh-examples/tree/main/examples/apps/colorapp).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
