### PR TITLE
Removed Hardcoded EKS Version and Nodegroup AMI Release Version. This…

### DIFF
--- a/blogs/eks-multi-account-spire/cf-templates/backend-template.json
+++ b/blogs/eks-multi-account-spire/cf-templates/backend-template.json
@@ -152,8 +152,7 @@
               "ServiceRole",
               "Arn"
             ]
-          },
-          "Version": "1.22"
+          }
         }
       },
       "ControlPlaneSecurityGroup": {
@@ -1048,7 +1047,6 @@
             ]
           },
           "NodegroupName": "nodegroup",
-          "ReleaseVersion": "1.22.17-20230127",
           "ScalingConfig": {
             "DesiredSize": 3,
             "MaxSize": 3,

--- a/blogs/eks-multi-account-spire/cf-templates/frontend-template.json
+++ b/blogs/eks-multi-account-spire/cf-templates/frontend-template.json
@@ -152,8 +152,7 @@
               "ServiceRole",
               "Arn"
             ]
-          },
-          "Version": "1.22"
+          }
         }
       },
       "ControlPlaneSecurityGroup": {
@@ -1048,7 +1047,6 @@
             ]
           },
           "NodegroupName": "nodegroup",
-          "ReleaseVersion": "1.22.17-20230127",
           "ScalingConfig": {
             "DesiredSize": 3,
             "MaxSize": 3,

--- a/blogs/eks-multi-account-spire/cf-templates/shared-services-template.json
+++ b/blogs/eks-multi-account-spire/cf-templates/shared-services-template.json
@@ -161,8 +161,7 @@
             "ServiceRole",
             "Arn"
           ]
-        },
-        "Version": "1.22"
+        }
       }
     },
     "ControlPlaneSecurityGroup": {
@@ -1098,7 +1097,6 @@
           ]
         },
         "NodegroupName": "nodegroup",
-        "ReleaseVersion": "1.22.17-20230127",
         "ScalingConfig": {
           "DesiredSize": 3,
           "MaxSize": 3,

--- a/blogs/eks-multi-account-spire/helper-scripts/ebs_for_spire_server.sh
+++ b/blogs/eks-multi-account-spire/helper-scripts/ebs_for_spire_server.sh
@@ -1,0 +1,41 @@
+export EBS_CSI_POLICY_NAME="Amazon_EBS_CSI_Driver_For_Spire_Server"
+
+
+# download the IAM policy document
+curl -sSL -o ebs-csi-policy.json https://raw.githubusercontent.com/kubernetes-sigs/aws-ebs-csi-driver/master/docs/example-iam-policy.json
+
+# Create the IAM policy
+aws iam create-policy \
+  --profile shared \
+  --policy-name ${EBS_CSI_POLICY_NAME} \
+  --policy-document file://ebs-csi-policy.json
+
+# export the policy ARN as a variable
+export EBS_CSI_POLICY_ARN=$(aws --profile shared iam list-policies --query 'Policies[?PolicyName==`'$EBS_CSI_POLICY_NAME'`].Arn' --output text)
+
+# Create a service account
+eksctl create iamserviceaccount \
+  --cluster eks-cluster-shared \
+  --name spire-server \
+  --profile shared \
+  --namespace kube-system \
+  --attach-policy-arn $EBS_CSI_POLICY_ARN \
+  --override-existing-serviceaccounts \
+  --approve
+
+# add the aws-ebs-csi-driver as a helm repo
+helm repo add aws-ebs-csi-driver https://kubernetes-sigs.github.io/aws-ebs-csi-driver
+
+helm upgrade --install aws-ebs-csi-driver \
+  --version=1.2.4 \
+  --namespace kube-system \
+  --set serviceAccount.controller.create=false \
+  --set serviceAccount.snapshot.create=false \
+  --set enableVolumeScheduling=true \
+  --set enableVolumeResizing=true \
+  --set enableVolumeSnapshot=true \
+  --set serviceAccount.snapshot.name=spire-server \
+  --set serviceAccount.controller.name=spire-server \
+  aws-ebs-csi-driver/aws-ebs-csi-driver
+
+kubectl -n kube-system rollout status deployment ebs-csi-controller


### PR DESCRIPTION
1) Hardcoded EKS Version and AMI Node Group Release Version are not required. It causes stacks to fail when versions are not supported. Removed the hardcoding and tested the cluster creation and node group creation picked the latest current versions automatically. 

2) Added EBS Controller Creation Script for Spire Server. Kube Config are loaded as Config Map Volumes and the Stateful State Pod stays in Pending as thier is no EBS CSI Crontroller. To fix this EBS CSI Controller script is added for sprie server pod to come up and mount the Volume.

