### PR TITLE
Upgrade envoy image version to 1.25.1.0 with public ECR repo

### DIFF
--- a/blogs/ecs-canary-deployments-pipeline/setup/scripts/export_environment_variables.sh
+++ b/blogs/ecs-canary-deployments-pipeline/setup/scripts/export_environment_variables.sh
@@ -4,7 +4,7 @@ set -e
 AWS_REGION=us-west-2
 ENVIRONMENT_NAME=ecs-blogpost
 NAMESPACE=yelb.local
-ENVOY_IMAGE=840364872350.dkr.ecr.${AWS_REGION}.amazonaws.com/aws-appmesh-envoy:v1.15.1.0-prod
+ENVOY_IMAGE=public.ecr.aws/appmesh/aws-appmesh-envoy:v1.25.1.0-prod
 SHARED_STACK_NAME=${ENVIRONMENT_NAME}-deployment-stepfunctions
 BUILD_COMPUTE_TYPE=BUILD_GENERAL1_SMALL
 USE_SAMPLE_MICROSERVICES='True'

--- a/blogs/ecs-service-connectivity/yelb/deployments/platformdeployment/AWS/ECS/sample.settings
+++ b/blogs/ecs-service-connectivity/yelb/deployments/platformdeployment/AWS/ECS/sample.settings
@@ -1,6 +1,6 @@
 export AWS_ACCOUNT_ID=<account-id>
 export AWS_DEFAULT_REGION="<region>"
-export ENVOY_IMAGE="840364872350.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/aws-appmesh-envoy:v1.12.2.1-prod"
+export ENVOY_IMAGE="public.ecr.aws/appmesh/aws-appmesh-envoy:v1.25.1.0-prod"
 export VPC="<vpc-id>"
 export PUBLIC_SUBNET_1="<subnet-id>"
 export PUBLIC_SUBNET_2="<subnet-id>"

--- a/blogs/eks-appmesh-connectivity/deployments/yaml/mesh/appmesh/yelb-gateway.yaml
+++ b/blogs/eks-appmesh-connectivity/deployments/yaml/mesh/appmesh/yelb-gateway.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
         - name: envoy
-          image: 840364872350.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-envoy:v1.15.1.0-prod
+          image: public.ecr.aws/appmesh/aws-appmesh-envoy:v1.25.1.0-prod
           ports:
             - containerPort: 8088
           resources:

--- a/blogs/eks-multi-account-spire/helper-scripts/app_mesh_setup.sh
+++ b/blogs/eks-multi-account-spire/helper-scripts/app_mesh_setup.sh
@@ -54,7 +54,7 @@ for PROFILE in shared frontend backend
       --set serviceAccount.create=false \
       --set serviceAccount.name=appmesh-controller \
       --set sds.enabled=true
-      # --set sidecar.image.tag=v1.16.3.0-prod
+      # --set sidecar.image.tag=v1.25.1.0-prod
 
     echo "Creating the yelb namespace..."
     kubectl create ns yelb

--- a/walkthroughs/howto-cross-account/vars.env
+++ b/walkthroughs/howto-cross-account/vars.env
@@ -8,6 +8,6 @@ export PROJECT_NAME=
 export AWS_DEFAULT_REGION=
 export KEY_PAIR=
 
-export ENVOY_IMAGE=840364872350.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/aws-appmesh-envoy:v1.15.1.0-prod
+export ENVOY_IMAGE=public.ecr.aws/appmesh/aws-appmesh-envoy:v1.25.1.0-prod
 export BACKEND_1_IMAGE=dockercloud/hello-world
 export BACKEND_2_IMAGE=karthequian/helloworld


### PR DESCRIPTION
Upgrade envoy image version to 1.25.1.0 with public ECR repo


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
