### PR TITLE
Replace APPMESH_VIRTUAL_NODE_NAME with APPMESH_RESOURCE_ARN

### DIFF
--- a/blogs/ecs-cross-account/account_backend/redis_and_database.yml
+++ b/blogs/ecs-cross-account/account_backend/redis_and_database.yml
@@ -183,7 +183,7 @@ Resources:
               awslogs-region: !Ref AWS::Region
               awslogs-stream-prefix: "database-envoy"
           Environment:
-            - Name: "APPMESH_VIRTUAL_NODE_NAME"
+            - Name: "APPMESH_RESOURCE_ARN"
               Value: !Sub "mesh/${MeshName}/virtualNode/yelb-db-vn"
             - Name: "ENVOY_LOG_LEVEL"
               Value: "debug"
@@ -311,7 +311,7 @@ Resources:
               awslogs-region: !Ref AWS::Region
               awslogs-stream-prefix: "redis-envoy"
           Environment:
-            - Name: "APPMESH_VIRTUAL_NODE_NAME"
+            - Name: "APPMESH_RESOURCE_ARN"
               Value: !Sub "mesh/${MeshName}/virtualNode/redis-server-vn"
             - Name: "ENVOY_LOG_LEVEL"
               Value: "debug"

--- a/blogs/ecs-cross-account/account_frontend/app_and_frontend.yml
+++ b/blogs/ecs-cross-account/account_frontend/app_and_frontend.yml
@@ -263,7 +263,7 @@ Resources:
               awslogs-region: !Ref AWS::Region
               awslogs-stream-prefix: "appserver-envoy"
           Environment:
-            - Name: "APPMESH_VIRTUAL_NODE_NAME"
+            - Name: "APPMESH_RESOURCE_ARN"
               Value: !Sub "mesh/${MeshName}@${MeshOwner}/virtualNode/yelb-appserver-vn"
             - Name: "ENVOY_LOG_LEVEL"
               Value: "debug"
@@ -394,7 +394,7 @@ Resources:
               awslogs-region: !Ref AWS::Region
               awslogs-stream-prefix: "ui-envoy"
           Environment:
-            - Name: "APPMESH_VIRTUAL_NODE_NAME"
+            - Name: "APPMESH_RESOURCE_ARN"
               Value: !Sub "mesh/${MeshName}@${MeshOwner}/virtualNode/yelb-ui-vn"
             - Name: "ENVOY_LOG_LEVEL"
               Value: "debug"

--- a/blogs/ecs-ec2-crossvpc-with-tls/appmesh-baseline.yml
+++ b/blogs/ecs-ec2-crossvpc-with-tls/appmesh-baseline.yml
@@ -82,7 +82,7 @@ Resources:
           Essential: true
           User: 1337
           Environment:
-           - Name: "APPMESH_VIRTUAL_NODE_NAME"
+           - Name: "APPMESH_RESOURCE_ARN"
              Value: "mesh/appmesh-workshop/virtualNode/crystal-lb-vanilla"
           HealthCheck:
             Command:

--- a/blogs/ecs-ec2-crossvpc-with-tls/appmesh-nodejs.yml
+++ b/blogs/ecs-ec2-crossvpc-with-tls/appmesh-nodejs.yml
@@ -70,7 +70,7 @@ Resources:
           Essential: true
           User: 1337
           Environment:
-           - Name: "APPMESH_VIRTUAL_NODE_NAME"
+           - Name: "APPMESH_RESOURCE_ARN"
              Value: "mesh/appmesh-workshop/virtualNode/nodejs-lb-strawberry"
           HealthCheck:
             Command:

--- a/blogs/ecs-ec2-crossvpc-with-tls/frontend-envoy.sh
+++ b/blogs/ecs-ec2-crossvpc-with-tls/frontend-envoy.sh
@@ -45,7 +45,7 @@ mainSteps:
         $(aws ecr get-login --no-include-email --region {{region}} --registry-ids 840364872350)
         # Install and run envoy
         sudo docker run --detach \
-          --env APPMESH_VIRTUAL_NODE_NAME=mesh/{{meshName}}/virtualNode/{{vNodeName}} \
+          --env APPMESH_RESOURCE_ARN=mesh/{{meshName}}/virtualNode/{{vNodeName}} \
           --env ENABLE_ENVOY_XRAY_TRACING=1 \
           --log-driver=awslogs \
           --log-opt awslogs-region={{region}} \

--- a/blogs/ecs-service-connectivity/yelb/deployments/platformdeployment/AWS/ECS/yelb-cloudformation-ECS-AppMesh-deployment.yaml
+++ b/blogs/ecs-service-connectivity/yelb/deployments/platformdeployment/AWS/ECS/yelb-cloudformation-ECS-AppMesh-deployment.yaml
@@ -200,7 +200,7 @@ Resources:
                         Value: '1'
                       - Name: ENABLE_ENVOY_DOG_STATSD
                         Value: '1'
-                      - Name: APPMESH_VIRTUAL_NODE_NAME
+                      - Name: APPMESH_RESOURCE_ARN
                         Value:
                             Fn::Join:
                                 - ''
@@ -274,7 +274,7 @@ Resources:
                         Value: '1'
                       - Name: STATSD_PORT
                         Value: '8125'
-                      - Name: APPMESH_VIRTUAL_NODE_NAME
+                      - Name: APPMESH_RESOURCE_ARN
                         Value:
                             Fn::Join:
                                 - ''
@@ -419,7 +419,7 @@ Resources:
                         Value: '1'
                       - Name: ENABLE_ENVOY_DOG_STATSD
                         Value: '1'
-                      - Name: APPMESH_VIRTUAL_NODE_NAME
+                      - Name: APPMESH_RESOURCE_ARN
                         Value:
                             Fn::Join:
                                 - ''

--- a/examples/apps/colorapp/ecs/envoy-container.json
+++ b/examples/apps/colorapp/ecs/envoy-container.json
@@ -29,7 +29,7 @@
   ],
   "environment": [
     {
-      "name": "APPMESH_VIRTUAL_NODE_NAME",
+      "name": "APPMESH_RESOURCE_ARN",
       "value": $VIRTUAL_NODE
     },
     {

--- a/examples/apps/colorapp/kubernetes/generate-templates.sh
+++ b/examples/apps/colorapp/kubernetes/generate-templates.sh
@@ -51,7 +51,7 @@ spec:
           securityContext:
             runAsUser: 1337
           env:
-            - name: "APPMESH_VIRTUAL_NODE_NAME"
+            - name: "APPMESH_RESOURCE_ARN"
               value: "mesh/${MESH_NAME}/virtualNode/colorgateway-vn"
             - name: "ENVOY_LOG_LEVEL"
               value: "debug"
@@ -126,7 +126,7 @@ spec:
           securityContext:
             runAsUser: 1337
           env:
-            - name: "APPMESH_VIRTUAL_NODE_NAME"
+            - name: "APPMESH_RESOURCE_ARN"
               value: "mesh/${MESH_NAME}/virtualNode/colorteller-white-vn"
             - name: "ENVOY_LOG_LEVEL"
               value: "debug"
@@ -202,7 +202,7 @@ spec:
           securityContext:
             runAsUser: 1337
           env:
-            - name: "APPMESH_VIRTUAL_NODE_NAME"
+            - name: "APPMESH_RESOURCE_ARN"
               value: "mesh/${MESH_NAME}/virtualNode/colorteller-black-vn"
             - name: "ENVOY_LOG_LEVEL"
               value: "debug"
@@ -277,7 +277,7 @@ spec:
           securityContext:
             runAsUser: 1337
           env:
-            - name: "APPMESH_VIRTUAL_NODE_NAME"
+            - name: "APPMESH_RESOURCE_ARN"
               value: "mesh/${MESH_NAME}/virtualNode/colorteller-blue-vn"
             - name: "ENVOY_LOG_LEVEL"
               value: "debug"
@@ -352,7 +352,7 @@ spec:
           securityContext:
             runAsUser: 1337
           env:
-            - name: "APPMESH_VIRTUAL_NODE_NAME"
+            - name: "APPMESH_RESOURCE_ARN"
               value: "mesh/${MESH_NAME}/virtualNode/colorteller-red-vn"
             - name: "ENVOY_LOG_LEVEL"
               value: "debug"

--- a/walkthroughs/fargate/envoy-container.json
+++ b/walkthroughs/fargate/envoy-container.json
@@ -29,7 +29,7 @@
   ],
   "environment": [
     {
-      "name": "APPMESH_VIRTUAL_NODE_NAME",
+      "name": "APPMESH_RESOURCE_ARN",
       "value": $VIRTUAL_NODE
     },
     {

--- a/walkthroughs/howto-alb/app.yaml
+++ b/walkthroughs/howto-alb/app.yaml
@@ -353,7 +353,7 @@ Resources:
               Value: '1'
             - Name: 'ENABLE_ENVOY_STATS_TAGS'
               Value: '1'
-            - Name: 'APPMESH_VIRTUAL_NODE_NAME'
+            - Name: 'APPMESH_RESOURCE_ARN'
               Value:
                 Fn::Join:
                   - ''
@@ -694,7 +694,7 @@ Resources:
               Value: '1'
             - Name: 'ENABLE_ENVOY_STATS_TAGS'
               Value: '1'
-            - Name: 'APPMESH_VIRTUAL_NODE_NAME'
+            - Name: 'APPMESH_RESOURCE_ARN'
               Value:
                 Fn::Join:
                   - ''

--- a/walkthroughs/howto-cross-account/primary-account/app.yaml
+++ b/walkthroughs/howto-cross-account/primary-account/app.yaml
@@ -314,7 +314,7 @@ Resources:
             awslogs-region: !Ref AWS::Region
             awslogs-stream-prefix: 'backend-envoy'
         Environment:
-        - Name: 'APPMESH_VIRTUAL_NODE_NAME'
+        - Name: 'APPMESH_RESOURCE_ARN'
           Value: !Sub 'mesh/${ProjectName}-mesh/virtualNode/backend-1-vn'
         - Name: 'ENVOY_LOG_LEVEL'
           Value: 'debug'

--- a/walkthroughs/howto-cross-account/secondary-account/app.yaml
+++ b/walkthroughs/howto-cross-account/secondary-account/app.yaml
@@ -171,7 +171,7 @@ Resources:
             awslogs-region: !Ref AWS::Region
             awslogs-stream-prefix: 'backend-envoy'
         Environment:
-        - Name: 'APPMESH_VIRTUAL_NODE_NAME'
+        - Name: 'APPMESH_RESOURCE_ARN'
           Value: !Sub 'mesh/${ProjectName}-mesh@${MeshOwner}/virtualNode/backend-2-vn'
         - Name: 'ENVOY_LOG_LEVEL'
           Value: 'debug'

--- a/walkthroughs/howto-ecs-basics/deploy/2-meshify.yaml
+++ b/walkthroughs/howto-ecs-basics/deploy/2-meshify.yaml
@@ -443,7 +443,7 @@ Resources:
               Value: '1'
             - Name: 'ENABLE_ENVOY_DOG_STATSD'
               Value: '1'
-            - Name: 'APPMESH_VIRTUAL_NODE_NAME'
+            - Name: 'APPMESH_RESOURCE_ARN'
               Value:
                 Fn::Join:
                   - ''
@@ -677,7 +677,7 @@ Resources:
               Value: '1'
             - Name: 'ENABLE_ENVOY_DOG_STATSD'
               Value: '1'
-            - Name: 'APPMESH_VIRTUAL_NODE_NAME'
+            - Name: 'APPMESH_RESOURCE_ARN'
               Value:
                 Fn::Join:
                   - ''

--- a/walkthroughs/howto-ecs-basics/deploy/3-routing.yaml
+++ b/walkthroughs/howto-ecs-basics/deploy/3-routing.yaml
@@ -443,7 +443,7 @@ Resources:
               Value: '1'
             - Name: 'ENABLE_ENVOY_DOG_STATSD'
               Value: '1'
-            - Name: 'APPMESH_VIRTUAL_NODE_NAME'
+            - Name: 'APPMESH_RESOURCE_ARN'
               Value:
                 Fn::Join:
                   - ''
@@ -618,7 +618,7 @@ Resources:
               Value: '1'
             - Name: 'ENABLE_ENVOY_DOG_STATSD'
               Value: '1'
-            - Name: 'APPMESH_VIRTUAL_NODE_NAME'
+            - Name: 'APPMESH_RESOURCE_ARN'
               Value:
                 Fn::Join:
                   - ''
@@ -880,7 +880,7 @@ Resources:
               Value: '1'
             - Name: 'ENABLE_ENVOY_DOG_STATSD'
               Value: '1'
-            - Name: 'APPMESH_VIRTUAL_NODE_NAME'
+            - Name: 'APPMESH_RESOURCE_ARN'
               Value:
                 Fn::Join:
                   - ''

--- a/walkthroughs/howto-external-traffic/infrastructure/ecs-service.yaml
+++ b/walkthroughs/howto-external-traffic/infrastructure/ecs-service.yaml
@@ -123,7 +123,7 @@ Resources:
               awslogs-region: !Ref AWS::Region
               awslogs-stream-prefix: 'white-envoy'
           Environment:
-            - Name: 'APPMESH_VIRTUAL_NODE_NAME'
+            - Name: 'APPMESH_RESOURCE_ARN'
               Value: !Sub 'mesh/${AppMeshMeshName}/virtualNode/ColorTellerWhite'
             - Name: 'ENVOY_LOG_LEVEL'
               Value: 'debug'

--- a/walkthroughs/howto-grpc-ingress-gateway/app.yaml
+++ b/walkthroughs/howto-grpc-ingress-gateway/app.yaml
@@ -199,7 +199,7 @@ Resources:
             awslogs-region: !Ref AWS::Region
             awslogs-stream-prefix: 'color_gateway-envoy'
         Environment:
-        - Name: 'APPMESH_VIRTUAL_NODE_NAME'
+        - Name: 'APPMESH_RESOURCE_ARN'
           Value: !Sub 'mesh/${ProjectName}-mesh/virtualGateway/color_gateway'
         - Name: 'ENVOY_LOG_LEVEL'
           Value: 'debug'
@@ -311,7 +311,7 @@ Resources:
             awslogs-region: !Ref AWS::Region
             awslogs-stream-prefix: 'color_server-envoy'
         Environment:
-        - Name: 'APPMESH_VIRTUAL_NODE_NAME'
+        - Name: 'APPMESH_RESOURCE_ARN'
           Value: !Sub 'mesh/${ProjectName}-mesh/virtualNode/color_server'
         - Name: 'ENVOY_LOG_LEVEL'
           Value: 'debug'

--- a/walkthroughs/howto-grpc/app.yaml
+++ b/walkthroughs/howto-grpc/app.yaml
@@ -263,7 +263,7 @@ Resources:
             awslogs-region: !Ref AWS::Region
             awslogs-stream-prefix: 'color_client-envoy'
         Environment:
-        - Name: 'APPMESH_VIRTUAL_NODE_NAME'
+        - Name: 'APPMESH_RESOURCE_ARN'
           Value: !Sub 'mesh/${ProjectName}-mesh/virtualNode/color_client'
         - Name: 'ENVOY_LOG_LEVEL'
           Value: 'debug'
@@ -340,7 +340,7 @@ Resources:
             awslogs-region: !Ref AWS::Region
             awslogs-stream-prefix: 'color_server-envoy'
         Environment:
-        - Name: 'APPMESH_VIRTUAL_NODE_NAME'
+        - Name: 'APPMESH_RESOURCE_ARN'
           Value: !Sub 'mesh/${ProjectName}-mesh/virtualNode/color_server'
         - Name: 'ENVOY_LOG_LEVEL'
           Value: 'debug'

--- a/walkthroughs/howto-http-headers/app.yaml
+++ b/walkthroughs/howto-http-headers/app.yaml
@@ -652,7 +652,7 @@ Resources:
               awslogs-region: !Ref AWS::Region
               awslogs-stream-prefix: 'feapp-envoy'
           Environment:
-            - Name: 'APPMESH_VIRTUAL_NODE_NAME'
+            - Name: 'APPMESH_RESOURCE_ARN'
               Value: !Sub 'mesh/${ProjectName}/virtualNode/front-node'
             - Name: 'ENVOY_LOG_LEVEL'
               Value: 'debug'
@@ -730,7 +730,7 @@ Resources:
               awslogs-region: !Ref AWS::Region
               awslogs-stream-prefix: 'blue-envoy'
           Environment:
-            - Name: 'APPMESH_VIRTUAL_NODE_NAME'
+            - Name: 'APPMESH_RESOURCE_ARN'
               Value: !Sub 'mesh/${ProjectName}/virtualNode/blue-node'
 
   GreenTaskDef:
@@ -806,7 +806,7 @@ Resources:
               awslogs-region: !Ref AWS::Region
               awslogs-stream-prefix: 'green-envoy'
           Environment:
-            - Name: 'APPMESH_VIRTUAL_NODE_NAME'
+            - Name: 'APPMESH_RESOURCE_ARN'
               Value: !Sub 'mesh/${ProjectName}/virtualNode/green-node'
 
   RedTaskDef:
@@ -882,7 +882,7 @@ Resources:
               awslogs-region: !Ref AWS::Region
               awslogs-stream-prefix: 'red-envoy'
           Environment:
-            - Name: 'APPMESH_VIRTUAL_NODE_NAME'
+            - Name: 'APPMESH_RESOURCE_ARN'
               Value: !Sub 'mesh/${ProjectName}/virtualNode/red-node'
 
   YellowTaskDef:
@@ -958,7 +958,7 @@ Resources:
               awslogs-region: !Ref AWS::Region
               awslogs-stream-prefix: 'yellow-envoy'
           Environment:
-            - Name: 'APPMESH_VIRTUAL_NODE_NAME'
+            - Name: 'APPMESH_RESOURCE_ARN'
               Value: !Sub 'mesh/${ProjectName}/virtualNode/yellow-node'
 
   PurpleTaskDef:
@@ -1034,7 +1034,7 @@ Resources:
               awslogs-region: !Ref AWS::Region
               awslogs-stream-prefix: 'purple-envoy'
           Environment:
-            - Name: 'APPMESH_VIRTUAL_NODE_NAME'
+            - Name: 'APPMESH_RESOURCE_ARN'
               Value: !Sub 'mesh/${ProjectName}/virtualNode/purple-node'
 
   WhiteTaskDef:
@@ -1110,7 +1110,7 @@ Resources:
               awslogs-region: !Ref AWS::Region
               awslogs-stream-prefix: 'white-envoy'
           Environment:
-            - Name: 'APPMESH_VIRTUAL_NODE_NAME'
+            - Name: 'APPMESH_RESOURCE_ARN'
               Value: !Sub 'mesh/${ProjectName}/virtualNode/white-node'
 
   BlackTaskDef:
@@ -1186,7 +1186,7 @@ Resources:
               awslogs-region: !Ref AWS::Region
               awslogs-stream-prefix: 'black-envoy'
           Environment:
-            - Name: 'APPMESH_VIRTUAL_NODE_NAME'
+            - Name: 'APPMESH_RESOURCE_ARN'
               Value: !Sub 'mesh/${ProjectName}/virtualNode/black-node'
 
   FrontService:

--- a/walkthroughs/howto-http-retries/app.yaml
+++ b/walkthroughs/howto-http-retries/app.yaml
@@ -355,7 +355,7 @@ Resources:
               awslogs-region: !Ref AWS::Region
               awslogs-stream-prefix: 'feapp-envoy'
           Environment:
-            - Name: 'APPMESH_VIRTUAL_NODE_NAME'
+            - Name: 'APPMESH_RESOURCE_ARN'
               Value: !Sub 'mesh/${ProjectName}/virtualNode/front-node'
             - Name: 'ENVOY_LOG_LEVEL'
               Value: 'debug'
@@ -433,7 +433,7 @@ Resources:
               awslogs-region: !Ref AWS::Region
               awslogs-stream-prefix: 'blue-envoy'
           Environment:
-            - Name: 'APPMESH_VIRTUAL_NODE_NAME'
+            - Name: 'APPMESH_RESOURCE_ARN'
               Value: !Sub 'mesh/${ProjectName}/virtualNode/blue-node'
 
   FrontService:

--- a/walkthroughs/howto-http2/app.yaml
+++ b/walkthroughs/howto-http2/app.yaml
@@ -262,7 +262,7 @@ Resources:
             awslogs-region: !Ref AWS::Region
             awslogs-stream-prefix: 'color_client-envoy'
         Environment:
-        - Name: 'APPMESH_VIRTUAL_NODE_NAME'
+        - Name: 'APPMESH_RESOURCE_ARN'
           Value: !Sub 'mesh/${ProjectName}-mesh/virtualNode/color_client'
         - Name: 'ENVOY_LOG_LEVEL'
           Value: 'debug'
@@ -339,7 +339,7 @@ Resources:
             awslogs-region: !Ref AWS::Region
             awslogs-stream-prefix: 'color_server-red-envoy'
         Environment:
-        - Name: 'APPMESH_VIRTUAL_NODE_NAME'
+        - Name: 'APPMESH_RESOURCE_ARN'
           Value: !Sub 'mesh/${ProjectName}-mesh/virtualNode/color_server-red'
         - Name: 'ENVOY_LOG_LEVEL'
           Value: 'debug'
@@ -416,7 +416,7 @@ Resources:
             awslogs-region: !Ref AWS::Region
             awslogs-stream-prefix: 'color_server-green-envoy'
         Environment:
-        - Name: 'APPMESH_VIRTUAL_NODE_NAME'
+        - Name: 'APPMESH_RESOURCE_ARN'
           Value: !Sub 'mesh/${ProjectName}-mesh/virtualNode/color_server-green'
         - Name: 'ENVOY_LOG_LEVEL'
           Value: 'debug'
@@ -493,7 +493,7 @@ Resources:
             awslogs-region: !Ref AWS::Region
             awslogs-stream-prefix: 'color_server-blue-envoy'
         Environment:
-        - Name: 'APPMESH_VIRTUAL_NODE_NAME'
+        - Name: 'APPMESH_RESOURCE_ARN'
           Value: !Sub 'mesh/${ProjectName}-mesh/virtualNode/color_server-blue'
         - Name: 'ENVOY_LOG_LEVEL'
           Value: 'debug'

--- a/walkthroughs/howto-ingress-gateway/infrastructure/ecs-service.yaml
+++ b/walkthroughs/howto-ingress-gateway/infrastructure/ecs-service.yaml
@@ -126,7 +126,7 @@ Resources:
               awslogs-region: !Ref AWS::Region
               awslogs-stream-prefix: 'white-envoy'
           Environment:
-            - Name: 'APPMESH_VIRTUAL_NODE_NAME'
+            - Name: 'APPMESH_RESOURCE_ARN'
               Value: !Sub 'mesh/${AppMeshMeshName}/virtualNode/colorteller-white-vn'
 
   ColorTellerWhiteService:
@@ -245,7 +245,7 @@ Resources:
               awslogs-region: !Ref AWS::Region
               awslogs-stream-prefix: 'black-envoy'
           Environment:
-            - Name: 'APPMESH_VIRTUAL_NODE_NAME'
+            - Name: 'APPMESH_RESOURCE_ARN'
               Value: !Sub 'mesh/${AppMeshMeshName}/virtualNode/colorteller-black-vn'
 
   ColorTellerBlackService:
@@ -364,7 +364,7 @@ Resources:
               awslogs-region: !Ref AWS::Region
               awslogs-stream-prefix: 'blue-envoy'
           Environment:
-            - Name: 'APPMESH_VIRTUAL_NODE_NAME'
+            - Name: 'APPMESH_RESOURCE_ARN'
               Value: !Sub 'mesh/${AppMeshMeshName}/virtualNode/colorteller-blue-vn'
 
   ColorTellerBlueService:
@@ -483,7 +483,7 @@ Resources:
               awslogs-region: !Ref AWS::Region
               awslogs-stream-prefix: 'red-envoy'
           Environment:
-            - Name: 'APPMESH_VIRTUAL_NODE_NAME'
+            - Name: 'APPMESH_RESOURCE_ARN'
               Value: !Sub 'mesh/${AppMeshMeshName}/virtualNode/colorteller-red-vn'
 
   ColorTellerRedService:
@@ -565,7 +565,7 @@ Resources:
               awslogs-region: !Ref AWS::Region
               awslogs-stream-prefix: 'gateway-envoy'
           Environment:
-            - Name: 'APPMESH_VIRTUAL_NODE_NAME'
+            - Name: 'APPMESH_RESOURCE_ARN'
               Value: !Sub 'mesh/${AppMeshMeshName}/virtualGateway/colorgateway-vg'
             - Name: 'ENABLE_ENVOY_STATS_TAGS'
               Value: '1'

--- a/walkthroughs/howto-mutual-tls-file-provided-by-acm/infrastructure/deploy.yaml
+++ b/walkthroughs/howto-mutual-tls-file-provided-by-acm/infrastructure/deploy.yaml
@@ -687,7 +687,7 @@ Resources:
               awslogs-region: !Ref AWS::Region
               awslogs-stream-prefix: 'colorteller'
           Environment:
-            - Name: 'APPMESH_VIRTUAL_NODE_NAME'
+            - Name: 'APPMESH_RESOURCE_ARN'
               Value: !Sub 'mesh/${AppMeshMeshName}/virtualNode/colorteller-vn'
             - Name: AWS_REGION
               Value: !Ref 'AWS::Region'
@@ -783,7 +783,7 @@ Resources:
               awslogs-region: !Ref AWS::Region
               awslogs-stream-prefix: 'gateway'
           Environment:
-            - Name: 'APPMESH_VIRTUAL_NODE_NAME'
+            - Name: 'APPMESH_RESOURCE_ARN'
               Value: !Sub 'mesh/${AppMeshMeshName}/virtualGateway/gateway-vgw'
             - Name: AWS_REGION
               Value: !Ref 'AWS::Region'

--- a/walkthroughs/howto-mutual-tls-file-provided-by-acm/infrastructure/ecs-service.yaml
+++ b/walkthroughs/howto-mutual-tls-file-provided-by-acm/infrastructure/ecs-service.yaml
@@ -112,7 +112,7 @@ Resources:
               awslogs-region: !Ref AWS::Region
               awslogs-stream-prefix: 'colorteller'
           Environment:
-            - Name: 'APPMESH_VIRTUAL_NODE_NAME'
+            - Name: 'APPMESH_RESOURCE_ARN'
               Value: !Sub 'mesh/${AppMeshMeshName}/virtualNode/colorteller-vn'
             - Name: AWS_REGION
               Value: !Ref 'AWS::Region'
@@ -201,7 +201,7 @@ Resources:
               awslogs-region: !Ref AWS::Region
               awslogs-stream-prefix: 'gateway'
           Environment:
-            - Name: 'APPMESH_VIRTUAL_NODE_NAME'
+            - Name: 'APPMESH_RESOURCE_ARN'
               Value: !Sub 'mesh/${AppMeshMeshName}/virtualGateway/gateway-vgw'
             - Name: AWS_REGION
               Value: !Ref 'AWS::Region'

--- a/walkthroughs/howto-mutual-tls-file-provided/infrastructure/ecs-service.yaml
+++ b/walkthroughs/howto-mutual-tls-file-provided/infrastructure/ecs-service.yaml
@@ -106,7 +106,7 @@ Resources:
               awslogs-region: !Ref AWS::Region
               awslogs-stream-prefix: 'colorteller'
           Environment:
-            - Name: 'APPMESH_VIRTUAL_NODE_NAME'
+            - Name: 'APPMESH_RESOURCE_ARN'
               Value: !Sub 'mesh/${AppMeshMeshName}/virtualNode/colorteller-vn'
             - Name: CERTIFICATE_NAME
               Value: 'colorteller'
@@ -201,7 +201,7 @@ Resources:
               awslogs-region: !Ref AWS::Region
               awslogs-stream-prefix: 'gateway'
           Environment:
-            - Name: 'APPMESH_VIRTUAL_NODE_NAME'
+            - Name: 'APPMESH_RESOURCE_ARN'
               Value: !Sub 'mesh/${AppMeshMeshName}/virtualGateway/gateway-vgw'
             - Name: CERTIFICATE_NAME
               Value: 'gateway'

--- a/walkthroughs/howto-outlier-detection/application.yaml
+++ b/walkthroughs/howto-outlier-detection/application.yaml
@@ -346,7 +346,7 @@ Resources:
                 awslogs-region: !Ref AWS::Region
                 awslogs-stream-prefix: 'color-envoy'
             Environment:
-              - Name: 'APPMESH_VIRTUAL_NODE_NAME'
+              - Name: 'APPMESH_RESOURCE_ARN'
                 Value: !Ref ColorNodeName
     
     FrontService:

--- a/walkthroughs/howto-servicediscovery-cloudmap/app.yaml
+++ b/walkthroughs/howto-servicediscovery-cloudmap/app.yaml
@@ -302,7 +302,7 @@ Resources:
             awslogs-region: !Ref AWS::Region
             awslogs-stream-prefix: 'blue'
         Environment:
-        - Name: 'APPMESH_VIRTUAL_NODE_NAME'
+        - Name: 'APPMESH_RESOURCE_ARN'
           Value: !Sub 'mesh/${AWS::StackName}-mesh/virtualNode/colorteller-blue-node'
         - Name: 'ENVOY_LOG_LEVEL'
           Value: 'debug'
@@ -384,7 +384,7 @@ Resources:
             awslogs-region: !Ref AWS::Region
             awslogs-stream-prefix: 'green'
         Environment:
-        - Name: 'APPMESH_VIRTUAL_NODE_NAME'
+        - Name: 'APPMESH_RESOURCE_ARN'
           Value: !Sub 'mesh/${AWS::StackName}-mesh/virtualNode/colorteller-green-node'
         - Name: 'ENVOY_LOG_LEVEL'
           Value: 'debug'

--- a/walkthroughs/howto-timeout-policy/infrastructure/ecs-service.yaml
+++ b/walkthroughs/howto-timeout-policy/infrastructure/ecs-service.yaml
@@ -127,7 +127,7 @@ Resources:
               awslogs-region: !Ref AWS::Region
               awslogs-stream-prefix: 'white-envoy'
           Environment:
-            - Name: 'APPMESH_VIRTUAL_NODE_NAME'
+            - Name: 'APPMESH_RESOURCE_ARN'
               Value: !Sub 'mesh/${AppMeshMeshName}/virtualNode/ColorTellerWhite'
             - Name: 'APPMESH_PREVIEW'
               Value: '1'
@@ -251,7 +251,7 @@ Resources:
               awslogs-region: !Ref AWS::Region
               awslogs-stream-prefix: 'red-envoy'
           Environment:
-            - Name: 'APPMESH_VIRTUAL_NODE_NAME'
+            - Name: 'APPMESH_RESOURCE_ARN'
               Value: !Sub 'mesh/${AppMeshMeshName}/virtualNode/ColorTellerRed'
             - Name: 'APPMESH_PREVIEW'
               Value: '1'
@@ -376,7 +376,7 @@ Resources:
               awslogs-region: !Ref AWS::Region
               awslogs-stream-prefix: 'gateway-envoy'
           Environment:
-            - Name: 'APPMESH_VIRTUAL_NODE_NAME'
+            - Name: 'APPMESH_RESOURCE_ARN'
               Value: !Sub 'mesh/${AppMeshMeshName}/virtualNode/ColorGateway'
             - Name: 'APPMESH_PREVIEW'
               Value: '1'
@@ -467,7 +467,7 @@ Resources:
               awslogs-region: !Ref AWS::Region
               awslogs-stream-prefix: 'publicgateway-envoy'
           Environment:
-            - Name: 'APPMESH_VIRTUAL_NODE_NAME'
+            - Name: 'APPMESH_RESOURCE_ARN'
               Value: !Sub 'mesh/${AppMeshMeshName}/virtualGateway/publicgateway-vg'
             - Name: 'APPMESH_PREVIEW'
               Value: '1'

--- a/walkthroughs/howto-tls-file-provided/infrastructure/ecs-service.yaml
+++ b/walkthroughs/howto-tls-file-provided/infrastructure/ecs-service.yaml
@@ -127,7 +127,7 @@ Resources:
               awslogs-region: !Ref AWS::Region
               awslogs-stream-prefix: 'white-envoy'
           Environment:
-            - Name: 'APPMESH_VIRTUAL_NODE_NAME'
+            - Name: 'APPMESH_RESOURCE_ARN'
               Value: !Sub 'mesh/${AppMeshMeshName}/virtualNode/ColorTellerWhite'
             - Name: CERTIFICATE_NAME
               Value: 'colorteller_white'
@@ -248,7 +248,7 @@ Resources:
               awslogs-region: !Ref AWS::Region
               awslogs-stream-prefix: 'green-envoy'
           Environment:
-            - Name: 'APPMESH_VIRTUAL_NODE_NAME'
+            - Name: 'APPMESH_RESOURCE_ARN'
               Value: !Sub 'mesh/${AppMeshMeshName}/virtualNode/ColorTellerGreen'
             - Name: CERTIFICATE_NAME
               Value: 'colorteller_green'

--- a/walkthroughs/tls-with-acm/infrastructure/ecs-service.yaml
+++ b/walkthroughs/tls-with-acm/infrastructure/ecs-service.yaml
@@ -123,7 +123,7 @@ Resources:
               awslogs-region: !Ref AWS::Region
               awslogs-stream-prefix: 'white-envoy'
           Environment:
-            - Name: 'APPMESH_VIRTUAL_NODE_NAME'
+            - Name: 'APPMESH_RESOURCE_ARN'
               Value: !Sub 'mesh/${AppMeshMeshName}/virtualNode/ColorTellerWhite'
 
   ColorTellerWhiteService:


### PR DESCRIPTION
*Description of changes:* Replace deprecated environment variable APPMESH_VIRTUAL_NODE_NAME with APPMESH_RESOURCE_ARN by following the [AppMesh official documentation](https://docs.aws.amazon.com/app-mesh/latest/userguide/envoy-config.html). 

Maintain the value of the field to be only mesh name and resource name to keep it consistent with [other use cases](https://github.com/aws/aws-app-mesh-examples/search?q=APPMESH_RESOURCE_ARN) from this git repo. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
