### PR TITLE
Adds multiarch builds for k8s http2 example

### DIFF
--- a/walkthroughs/howto-k8s-http2/color_client/Dockerfile
+++ b/walkthroughs/howto-k8s-http2/color_client/Dockerfile
@@ -1,32 +1,24 @@
-FROM public.ecr.aws/amazonlinux/amazonlinux:2 AS builder
-RUN yum update -y && \
-    yum install -y ca-certificates unzip tar gzip git && \
-    yum clean all && \
-    rm -rf /var/cache/yum
+FROM --platform=${BUILDPLATFORM} golang:1.20 as builder
 
-RUN curl -LO https://golang.org/dl/go1.17.1.linux-amd64.tar.gz && \
-    tar -C /usr/local -xzvf go1.17.1.linux-amd64.tar.gz
-
-ENV PATH="${PATH}:/usr/local/go/bin"
-ENV GOPATH="${HOME}/go"
-ENV PATH="${PATH}:${GOPATH}/bin"
+WORKDIR /go/src/github.com/aws/aws-app-mesh-examples/walkthroughs/howto-http2/color_client
 
 # Use the default go proxy
 ARG GO_PROXY=https://proxy.golang.org
-
-WORKDIR /go/src/github.com/aws/aws-app-mesh-examples/walkthroughs/howto-http2/color_client
 
 # Set the proxies for the go compiler.
 ENV GOPROXY=$GO_PROXY
 
 # go.mod and go.sum go into their own layers.
 # This ensures `go mod download` happens only when go.mod and go.sum change.
-COPY go.mod .
-COPY go.sum .
+COPY go.mod go.sum ./
 RUN go mod download
 
 COPY . .
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix nocgo -o /color_client .
+
+ARG TARGETOS
+ARG TARGETARCH
+
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -a -installsuffix nocgo -o /color_client .
 
 FROM public.ecr.aws/amazonlinux/amazonlinux:2
 RUN yum update -y && \

--- a/walkthroughs/howto-k8s-http2/color_server/Dockerfile
+++ b/walkthroughs/howto-k8s-http2/color_server/Dockerfile
@@ -1,32 +1,24 @@
-FROM public.ecr.aws/amazonlinux/amazonlinux:2 AS builder
-RUN yum update -y && \
-    yum install -y ca-certificates unzip tar gzip git && \
-    yum clean all && \
-    rm -rf /var/cache/yum
+FROM --platform=${BUILDPLATFORM} golang:1.20 as builder
 
-RUN curl -LO https://golang.org/dl/go1.17.1.linux-amd64.tar.gz && \
-    tar -C /usr/local -xzvf go1.17.1.linux-amd64.tar.gz
-
-ENV PATH="${PATH}:/usr/local/go/bin"
-ENV GOPATH="${HOME}/go"
-ENV PATH="${PATH}:${GOPATH}/bin"
+WORKDIR /go/src/github.com/aws/aws-app-mesh-examples/walkthroughs/howto-http2/color_server
 
 # Use the default go proxy
 ARG GO_PROXY=https://proxy.golang.org
-
-WORKDIR /go/src/github.com/aws/aws-app-mesh-examples/walkthroughs/howto-http2/color_server
 
 # Set the proxies for the go compiler.
 ENV GOPROXY=$GO_PROXY
 
 # go.mod and go.sum go into their own layers.
 # This ensures `go mod download` happens only when go.mod and go.sum change.
-COPY go.mod .
-COPY go.sum .
+COPY go.mod go.sum ./
 RUN go mod download
 
 COPY . .
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix nocgo -o /color_server .
+
+ARG TARGETOS
+ARG TARGETARCH
+
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -a -installsuffix nocgo -o /color_server .
 
 FROM public.ecr.aws/amazonlinux/amazonlinux:2
 RUN yum update -y && \


### PR DESCRIPTION
This modifies the images used for the k8s http2 example to default support arm64 in addition to amd64. This should gracefully downgrade to existing behavior if run from an environment that does not support cross-building.

This is done on this example as it's the "main" k8s setup for walkthroughs for demoing multiarch k8s abilities. Further walkthroughs may be adapted in the future.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
