### PR TITLE
Remove howto-http-header https scheme

### DIFF
--- a/walkthroughs/howto-http-headers/app.yaml
+++ b/walkthroughs/howto-http-headers/app.yaml
@@ -417,7 +417,6 @@ Resources:
         HttpRoute:
           Match:
             Prefix: '/'
-            Scheme: "https"
           Action:
             WeightedTargets:
               - VirtualNode: 'black-node'


### PR DESCRIPTION
appmesh do not support https scheme, remove this field to make the example run
![image](https://github.com/aws/aws-app-mesh-examples/assets/123429070/6ad02663-b9f6-44a8-b1ed-bd30766e3e9c)


*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
