### PR TITLE
Version V2 for yelb app server  fails to run, missing gem rackup

### DIFF
--- a/walkthroughs/eks-getting-started/yelb-appserver-v2/Dockerfile
+++ b/walkthroughs/eks-getting-started/yelb-appserver-v2/Dockerfile
@@ -16,6 +16,7 @@ ENV RACK_ENV=production
 
 RUN gem install sinatra --no-document
 RUN gem install redis --no-document
+RUN gem install rackup --no-document
 ### hack to allow the setup of the pg gem (which would fail otherwise)
 RUN apt-get update
 RUN apt-get install libpq-dev zlib1g zlib1g-dev -y


### PR DESCRIPTION
… package

*Issue #, if available:*

*Description of changes:*

On going through the [blog](https://aws.amazon.com/blogs/containers/getting-started-with-app-mesh-and-eks/) which was authored in the past regarding getting started with App Mesh, at the 5th step where a new version of yelb app server is build. The docker image fails to run because its missing a gem rackup.

Error from the pod 
=================

k logs yelb-appserver-v2-588786cd57-mdf59 -n yelb
Defaulted container "yelb-appserver-v2" out of: yelb-appserver-v2, envoy, xray-daemon, proxyinit (init)
Sinatra could not start, the "rackup" gem was not found!

Add it to your bundle with:

    bundle add rackup

or install it with:

    gem install rackup

=================


 I made the change in the dockerfile and was able to deploy it successfully . This PR is for include the gem in the package 



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
