### PR TITLE
Resolving urllib3 and OpenSSL version mismatch for gunicorn upgrade

### DIFF
--- a/walkthroughs/howto-alb/colorapp/requirements.txt
+++ b/walkthroughs/howto-alb/colorapp/requirements.txt
@@ -1,3 +1,4 @@
 flask
 aws-xray-sdk
+urllib3<2
 gunicorn==19.9.0

--- a/walkthroughs/howto-alb/feapp/requirements.txt
+++ b/walkthroughs/howto-alb/feapp/requirements.txt
@@ -1,4 +1,5 @@
 flask
 requests
 aws-xray-sdk
+urllib3<2
 gunicorn==19.9.0

--- a/walkthroughs/howto-k8s-cloudmap/colorapp/requirements.txt
+++ b/walkthroughs/howto-k8s-cloudmap/colorapp/requirements.txt
@@ -1,3 +1,4 @@
 flask
 aws-xray-sdk
+urllib3<2
 gunicorn==19.9.0

--- a/walkthroughs/howto-k8s-cloudmap/feapp/requirements.txt
+++ b/walkthroughs/howto-k8s-cloudmap/feapp/requirements.txt
@@ -1,4 +1,5 @@
 flask
 requests
 aws-xray-sdk
+urllib3<2
 gunicorn==19.9.0

--- a/walkthroughs/howto-k8s-cross-cluster/colorapp/requirements.txt
+++ b/walkthroughs/howto-k8s-cross-cluster/colorapp/requirements.txt
@@ -1,3 +1,4 @@
 flask
 aws-xray-sdk
+urllib3<2
 gunicorn==19.9.0

--- a/walkthroughs/howto-k8s-cross-cluster/feapp/requirements.txt
+++ b/walkthroughs/howto-k8s-cross-cluster/feapp/requirements.txt
@@ -1,4 +1,5 @@
 flask
 requests
 aws-xray-sdk
+urllib3<2
 gunicorn==19.9.0

--- a/walkthroughs/howto-k8s-timeout-policy/colorapp/requirements.txt
+++ b/walkthroughs/howto-k8s-timeout-policy/colorapp/requirements.txt
@@ -1,3 +1,4 @@
 flask
 aws-xray-sdk
+urllib3<2
 gunicorn==19.9.0

--- a/walkthroughs/howto-k8s-timeout-policy/feapp/requirements.txt
+++ b/walkthroughs/howto-k8s-timeout-policy/feapp/requirements.txt
@@ -1,4 +1,5 @@
 flask
 requests
 aws-xray-sdk
+urllib3<2
 gunicorn==19.9.0


### PR DESCRIPTION
*Issue #, if available:*

This pull request from Dependabot #593 upgrades the gunicorn package from version 19.9.0 to 22.0.0. However, while building the Docker images, it installs the latest version of urllib3 by default. Amazon Linux 2, which is the base operating system for the Docker images, has OpenSSL 1.0.2k pre-installed. Unfortunately, urllib3 version 2.0 and later only support OpenSSL 1.1.1 and higher versions. This version mismatch results in the following error when building the Docker 
image:

ImportError: urllib3 v2.0 only supports OpenSSL 1.1.1+, currently the 'ssl' module is compiled with 'OpenSSL 1.0.2k-fips  26 Jan 2017'. See: https://github.com/urllib3/urllib3/issues/2168


*Description of changes:*
This commit freezes urllib3 version < 2. This is a temporary solution to unblock the gunicorn upgrade. In the future, we should consider either upgrading the OpenSSL version on our Amazon Linux 2 instances or using a different base image with a newer OpenSSL version pre-installed.

All packages that contains gunicorn are showed as below.

```
$ grep -r gunicorn .
./howto-k8s-cloudmap/feapp/requirements.txt:gunicorn==19.9.0
./howto-k8s-cloudmap/feapp/Dockerfile:CMD ["gunicorn", "app:app", "--config=config.py"]
./howto-k8s-cloudmap/colorapp/requirements.txt:gunicorn==19.9.0
./howto-k8s-cloudmap/colorapp/Dockerfile:CMD ["gunicorn", "app:app", "--config=config.py"]
./howto-alb/feapp/requirements.txt:gunicorn==19.9.0
./howto-alb/feapp/Dockerfile:CMD ["gunicorn", "app:app", "--config=config.py"]
./howto-alb/colorapp/requirements.txt:gunicorn==19.9.0
./howto-alb/colorapp/Dockerfile:CMD ["gunicorn", "app:app", "--config=config.py"]
./howto-k8s-cross-cluster/feapp/requirements.txt:gunicorn==19.9.0
./howto-k8s-cross-cluster/feapp/Dockerfile:CMD ["gunicorn", "app:app", "--config=config.py"]
./howto-k8s-cross-cluster/colorapp/requirements.txt:gunicorn==19.9.0
./howto-k8s-cross-cluster/colorapp/Dockerfile:CMD ["gunicorn", "app:app", "--config=config.py"]
./howto-k8s-timeout-policy/feapp/requirements.txt:gunicorn==19.9.0
./howto-k8s-timeout-policy/feapp/Dockerfile:CMD ["gunicorn", "app:app", "--config=config.py"]
./howto-k8s-timeout-policy/colorapp/requirements.txt:gunicorn==19.9.0
./howto-k8s-timeout-policy/colorapp/Dockerfile:CMD ["gunicorn", "app:app", "--config=config.py"]
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
