### PR TITLE
Upgrade gunicorn to 22.0.0 to avoid request smuggling

### DIFF
--- a/walkthroughs/howto-alb/colorapp/requirements.txt
+++ b/walkthroughs/howto-alb/colorapp/requirements.txt
@@ -1,4 +1,4 @@
 flask
 aws-xray-sdk
 urllib3<2
-gunicorn==19.9.0
+gunicorn==22.0.0

--- a/walkthroughs/howto-alb/feapp/requirements.txt
+++ b/walkthroughs/howto-alb/feapp/requirements.txt
@@ -2,4 +2,4 @@ flask
 requests
 aws-xray-sdk
 urllib3<2
-gunicorn==19.9.0
+gunicorn==22.0.0

--- a/walkthroughs/howto-k8s-cloudmap/colorapp/requirements.txt
+++ b/walkthroughs/howto-k8s-cloudmap/colorapp/requirements.txt
@@ -1,4 +1,4 @@
 flask
 aws-xray-sdk
 urllib3<2
-gunicorn==19.9.0
+gunicorn==22.0.0

--- a/walkthroughs/howto-k8s-cross-cluster/colorapp/requirements.txt
+++ b/walkthroughs/howto-k8s-cross-cluster/colorapp/requirements.txt
@@ -1,4 +1,4 @@
 flask
 aws-xray-sdk
 urllib3<2
-gunicorn==19.9.0
+gunicorn==22.0.0

--- a/walkthroughs/howto-k8s-cross-cluster/feapp/requirements.txt
+++ b/walkthroughs/howto-k8s-cross-cluster/feapp/requirements.txt
@@ -2,4 +2,4 @@ flask
 requests
 aws-xray-sdk
 urllib3<2
-gunicorn==19.9.0
+gunicorn==22.0.0

--- a/walkthroughs/howto-k8s-timeout-policy/colorapp/requirements.txt
+++ b/walkthroughs/howto-k8s-timeout-policy/colorapp/requirements.txt
@@ -1,4 +1,4 @@
 flask
 aws-xray-sdk
 urllib3<2
-gunicorn==19.9.0
+gunicorn==22.0.0

--- a/walkthroughs/howto-k8s-timeout-policy/feapp/requirements.txt
+++ b/walkthroughs/howto-k8s-timeout-policy/feapp/requirements.txt
@@ -2,4 +2,4 @@ flask
 requests
 aws-xray-sdk
 urllib3<2
-gunicorn==19.9.0
+gunicorn==22.0.0


### PR DESCRIPTION
*Issue #, if available:*
Gunicorn fails to properly validate Transfer-Encoding headers, leading to HTTP Request Smuggling (HRS) vulnerabilities. By crafting requests with conflicting Transfer-Encoding headers, attackers can bypass security restrictions and access restricted endpoints. This issue is due to Gunicorn's handling of Transfer-Encoding headers, where it incorrectly processes requests with multiple, conflicting Transfer-Encoding headers, treating them as chunked regardless of the final encoding specified. This vulnerability has been shown to allow access to endpoints restricted by gunicorn. This issue has been addressed in version 22.0.0.

To be affected users must have a network path which does not filter out invalid requests. These users are advised to block access to restricted endpoints via a firewall or other mechanism if they are unable to update.

*Description of changes:*
Upgrade gunicorn package to 22.0.0. Instructions with modifications are locally tested.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
