### PR TITLE
Fix mtls walkthroughs

### DIFF
--- a/walkthroughs/howto-k8s-http2/color_client/Dockerfile
+++ b/walkthroughs/howto-k8s-http2/color_client/Dockerfile
@@ -4,8 +4,8 @@ RUN yum update -y && \
     yum clean all && \
     rm -rf /var/cache/yum
 
-RUN curl -LO https://golang.org/dl/go1.17.1.linux-amd64.tar.gz && \
-    tar -C /usr/local -xzvf go1.17.1.linux-amd64.tar.gz
+RUN curl -LO https://golang.org/dl/go1.26.0.linux-amd64.tar.gz && \
+    tar -C /usr/local -xzvf go1.26.0.linux-amd64.tar.gz
 
 ENV PATH="${PATH}:/usr/local/go/bin"
 ENV GOPATH="${HOME}/go"

--- a/walkthroughs/howto-k8s-http2/color_server/Dockerfile
+++ b/walkthroughs/howto-k8s-http2/color_server/Dockerfile
@@ -4,8 +4,8 @@ RUN yum update -y && \
     yum clean all && \
     rm -rf /var/cache/yum
 
-RUN curl -LO https://golang.org/dl/go1.17.1.linux-amd64.tar.gz && \
-    tar -C /usr/local -xzvf go1.17.1.linux-amd64.tar.gz
+RUN curl -LO https://golang.org/dl/go1.26.0.linux-amd64.tar.gz && \
+    tar -C /usr/local -xzvf go1.26.0.linux-amd64.tar.gz
 
 ENV PATH="${PATH}:/usr/local/go/bin"
 ENV GOPATH="${HOME}/go"

--- a/walkthroughs/howto-k8s-mtls-sds-based/spire/register_server_entries.sh
+++ b/walkthroughs/howto-k8s-mtls-sds-based/spire/register_server_entries.sh
@@ -3,7 +3,9 @@
 set -e
 
 register_server_entries() {
-    kubectl exec -n spire spire-server-0 -c spire-server -- /opt/spire/bin/spire-server entry create $@
+    # Get the actual SPIRE server pod name (works with both StatefulSet and Deployment)
+    SPIRE_SERVER_POD=$(kubectl get pod -n spire -l app=spire-server -o jsonpath='{.items[0].metadata.name}')
+    kubectl exec -n spire $SPIRE_SERVER_POD -c spire-server -- /opt/spire/bin/spire-server entry create $@
 }
 
 

--- a/walkthroughs/howto-k8s-mtls-sds-based/spire/spire_setup.yaml
+++ b/walkthroughs/howto-k8s-mtls-sds-based/spire/spire_setup.yaml
@@ -201,6 +201,7 @@ spec:
       spec:
         accessModes:
           - ReadWriteOnce
+        storageClassName: gp2
         resources:
           requests:
             storage: 1Gi

--- a/walkthroughs/howto-k8s-mtls-sds-based/spire/spire_setup.yaml
+++ b/walkthroughs/howto-k8s-mtls-sds-based/spire/spire_setup.yaml
@@ -147,7 +147,7 @@ data:
     }
 ---
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: spire-server
   namespace: spire
@@ -158,6 +158,7 @@ spec:
   selector:
     matchLabels:
       app: spire-server
+  serviceName: spire-server
   template:
     metadata:
       namespace: spire
@@ -193,8 +194,16 @@ spec:
         - name: spire-config
           configMap:
             name: spire-server
-        - name: spire-data
-          emptyDir: {}
+  volumeClaimTemplates:
+    - metadata:
+        name: spire-data
+        namespace: spire
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1Gi
 ---
 apiVersion: v1
 kind: Service

--- a/walkthroughs/howto-k8s-mtls-sds-based/spire/spire_setup.yaml
+++ b/walkthroughs/howto-k8s-mtls-sds-based/spire/spire_setup.yaml
@@ -100,13 +100,12 @@ data:
     server {
       bind_address = "0.0.0.0"
       bind_port = "8081"
-      registration_uds_path = "/tmp/spire-registration.sock"
       trust_domain = "howto-k8s-mtls-sds-based.aws"
       data_dir = "/run/spire/data"
       log_level = "DEBUG"
       ca_key_type = "rsa-2048"
 
-      default_svid_ttl = "1h"
+      default_x509_svid_ttl = "1h"
       ca_subject = {
         country = ["US"],
         organization = ["SPIFFE"],
@@ -127,14 +126,10 @@ data:
           clusters = {
             "k8s-cluster" = {
               use_token_review_api_validation = true
-              service_account_whitelist = ["spire:spire-agent"]
+              service_account_allow_list = ["spire:spire-agent"]
             }
           }
         }
-      }
-
-      NodeResolver "noop" {
-        plugin_data {}
       }
 
       KeyManager "disk" {
@@ -145,12 +140,14 @@ data:
 
       Notifier "k8sbundle" {
         plugin_data {
+          namespace = "spire"
+          config_map = "spire-bundle"
         }
       }
     }
 ---
 apiVersion: apps/v1
-kind: StatefulSet
+kind: Deployment
 metadata:
   name: spire-server
   namespace: spire
@@ -161,7 +158,6 @@ spec:
   selector:
     matchLabels:
       app: spire-server
-  serviceName: spire-server
   template:
     metadata:
       namespace: spire
@@ -171,7 +167,7 @@ spec:
       serviceAccountName: spire-server
       containers:
         - name: spire-server
-          image: gcr.io/spiffe-io/spire-server:0.12.0
+          image: ghcr.io/spiffe/spire-server:1.8.0
           args:
             - -config
             - /run/spire/config/server.conf
@@ -197,16 +193,8 @@ spec:
         - name: spire-config
           configMap:
             name: spire-server
-  volumeClaimTemplates:
-    - metadata:
-        name: spire-data
-        namespace: spire
-      spec:
-        accessModes:
-          - ReadWriteOnce
-        resources:
-          requests:
-            storage: 1Gi
+        - name: spire-data
+          emptyDir: {}
 ---
 apiVersion: v1
 kind: Service
@@ -238,7 +226,6 @@ data:
       socket_path = "/run/spire/sockets/agent.sock"
       trust_bundle_path = "/run/spire/bundle/bundle.crt"
       trust_domain = "howto-k8s-mtls-sds-based.aws"
-      enable_sds = true
     }
 
     plugins {
@@ -286,13 +273,9 @@ spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       serviceAccountName: spire-agent
-      initContainers:
-        - name: init
-          image: gcr.io/spiffe-io/wait-for-it
-          args: ["-t", "30", "spire-server:8081"]
       containers:
         - name: spire-agent
-          image: gcr.io/spiffe-io/spire-agent:0.12.0
+          image: ghcr.io/spiffe/spire-agent:1.8.0
           args: ["-config", "/run/spire/config/agent.conf"]
           volumeMounts:
             - name: spire-config

--- a/walkthroughs/howto-k8s-mtls-sds-based/v1beta2/manifest.yaml.template
+++ b/walkthroughs/howto-k8s-mtls-sds-based/v1beta2/manifest.yaml.template
@@ -44,7 +44,6 @@ spec:
     clientPolicy:
       tls:
         enforce: true
-        mode: STRICT
         certificate:
           sds:
             secretName: ${FRONTEND_APP_SVID}


### PR DESCRIPTION
#### Summary
Updates the `howto-k8s-mtls-sds-based` walkthrough to work with current App Mesh controller and SPIRE versions. Also upgrades Go in the `howto-k8s-http2` walkthrough Dockerfiles.

#### Key Changes

**Fixed invalid TLS field in ClientPolicyTLS**
- Removed `mode: STRICT` from `clientPolicy.tls` in the `front` VirtualNode template. The `mode` field is only valid on `ListenerTLS` (server-side), not `ClientPolicyTLS`. Client-side mTLS is correctly enforced via `enforce: true`. API ref: https://docs.aws.amazon.com/app-mesh/latest/APIReference/API_ClientPolicyTls.html

**Upgraded SPIRE v0.12.0 → v1.8.0**
- Updated server and agent images from `gcr.io/spiffe-io/spire-*:0.12.0` to `ghcr.io/spiffe/spire-*:1.8.0`
- Updated deprecated/renamed config fields: `registration_uds_path` (removed), `default_svid_ttl` → `default_x509_svid_ttl`, `service_account_whitelist` → `service_account_allow_list`, `NodeResolver "noop"` (removed), `enable_sds` (removed, default in v1.x)
- Added required `namespace` and `config_map` fields to `Notifier "k8sbundle"`
- Removed `wait-for-it` init container

**StatefulSet with persistent EBS storage for SPIRE server**
- Retained StatefulSet (from original) with `volumeClaimTemplates` using `gp2` storage class
- Added `storageClassName: gp2` to ensure EBS volumes are provisioned via EBS CSI driver
- Added EBS CSI driver setup instructions to README prerequisites

**Dynamic SPIRE server pod name resolution**
- Updated `register_server_entries.sh` and README commands to dynamically resolve the SPIRE server pod name via label selector instead of hardcoding `spire-server-0`

**Go version upgrade (http2 walkthrough)**
- Updated Go from 1.17.1 → 1.26.0 in `howto-k8s-http2` color_client and color_server Dockerfiles

#### Testing
- All pods running (2/2 containers including Envoy sidecar)
- VirtualNodes created successfully in App Mesh
- mTLS handshake working between services
- Health checks passing after TLS establishment
- SPIRE certificates properly issued and validated